### PR TITLE
Don't try to use Sentry when `SENTRY_DSN` is not set

### DIFF
--- a/apps/bot/src/base.ts
+++ b/apps/bot/src/base.ts
@@ -1,7 +1,11 @@
 import { Hashira } from "@hashira/core";
+import env from "@hashira/env";
 import { captureException } from "@sentry/bun";
 import { database } from "./db";
 
 export const base = new Hashira({ name: "base" })
   .use(database)
-  .addExceptionHandler(captureException);
+  .addExceptionHandler((e) => {
+    if (env.SENTRY_DSN) captureException(e);
+    console.error(e);
+  });

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -9,10 +9,12 @@ import { miscellaneous } from "./miscellaneous";
 import { moderation } from "./moderation";
 import { userActivity } from "./userActivity";
 
-Sentry.init({
-  dsn: env.SENTRY_DSN,
-  tracesSampleRate: 1.0, // Capture 100% of the transactions
-});
+if (env.SENTRY_DSN) {
+  Sentry.init({
+    dsn: env.SENTRY_DSN,
+    tracesSampleRate: 1.0, // Capture 100% of the transactions
+  });
+}
 
 export const bot = new Hashira({ name: "bot" })
   .use(base)
@@ -29,6 +31,8 @@ if (import.meta.main) {
   try {
     await bot.start(env.BOT_TOKEN);
   } catch (e) {
-    Sentry.captureException(e);
+    if (env.SENTRY_DSN) Sentry.captureException(e);
+    console.error(e);
+    throw e;
   }
 }

--- a/packages/env/index.ts
+++ b/packages/env/index.ts
@@ -10,7 +10,7 @@ export const Env = Type.Object({
   POSTGRES_PASSWORD: Type.String(),
   POSTGRES_USER: Type.String(),
   POSTGRES_TEST_HOST: Type.String(),
-  SENTRY_DSN: Type.String(),
+  SENTRY_DSN: Type.Optional(Type.String()),
 });
 
 export type Env = Static<typeof Env>;


### PR DESCRIPTION
Also change the error handling to log errors from command handlers. The root level error handler also re-throws the exception, as an error on the top level usually means some more serious problems.