### PR TITLE
Głosowania w DM

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -1,27 +1,25 @@
-version: '3.8'
-
 services:
   app:
-    build: 
+    build:
       context: .
       dockerfile: Dockerfile
     env_file: ../.env
 
     volumes:
       - ../..:/workspaces:cached
-      
+
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
     networks:
       - db
 
-    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally. 
+    # Use "forwardPorts" in **devcontainer.json** to forward an app port locally.
     # (Adding the "ports" property to this file will not forward from a Codespace.)
 
   db:
     image: postgres:latest
     restart: unless-stopped
-    networks: 
+    networks:
       - db
     volumes:
       - postgres-data:/var/lib/postgresql/data
@@ -31,7 +29,7 @@ services:
     image: postgres:latest
     restart: unless-stopped
     env_file: ../.env
-    networks: 
+    networks:
       - db
     volumes:
       - postgres-test-data:/var/lib/postgresql/data

--- a/apps/bot/src/dmVoting.ts
+++ b/apps/bot/src/dmVoting.ts
@@ -410,9 +410,9 @@ export const dmVoting = new Hashira({ name: "dmVoting" })
                 (m) => m.messageId === null,
               );
               lines.push(
-                `Nie udało się wysłać wiadomości do: ${failedToSendMessages
-                  .map(({ member }) => member.user.tag)
-                  .join(", ")}`,
+                `Nie udało się wysłać wiadomości do:\n${failedToSendMessages
+                  .map(({ member }) => `${member.user.tag} ${member.user.id}`)
+                  .join("\n")}`,
               );
             }
 

--- a/apps/bot/src/dmVoting.ts
+++ b/apps/bot/src/dmVoting.ts
@@ -16,6 +16,7 @@ import {
   bold,
   italic,
   time,
+  userMention,
 } from "discord.js";
 import { base } from "./base";
 import { discordTry } from "./util/discordTry";
@@ -306,10 +307,23 @@ export const dmVoting = new Hashira({ name: "dmVoting" })
                 );
               }
 
+              // Participants who received the message
+              const eliglibleParticipants = poll.participants.filter(
+                (p) => p.messageId !== null,
+              );
+              const failedParticipants = poll.participants.filter(
+                (p) => p.messageId === null,
+              );
               embed.addFields([
                 {
-                  name: `Odpowiedzi (${totalVotes}/${poll.participants.length})`,
+                  name: `Odpowiedzi (${totalVotes}/${eliglibleParticipants.length})`,
                   value: optionResults.join("\n"),
+                },
+                {
+                  name: `Nieotrzymane wiadomości (${failedParticipants.length})`,
+                  value: failedParticipants
+                    .map(({ userId }) => `${userMention(userId)} (${userId})`)
+                    .join("\n"),
                 },
               ]);
             }

--- a/apps/bot/src/dmVoting.ts
+++ b/apps/bot/src/dmVoting.ts
@@ -1,0 +1,171 @@
+import { Hashira, PaginatedView } from "@hashira/core";
+import { type DMPoll, type DMPollOption, DatabasePaginator } from "@hashira/db";
+import { PaginatorOrder } from "@hashira/paginate";
+import {
+  ActionRowBuilder,
+  type ModalActionRowComponentBuilder,
+  ModalBuilder,
+  PermissionFlagsBits,
+  TextInputBuilder,
+  TextInputStyle,
+  TimestampStyles,
+  bold,
+  italic,
+  time,
+} from "discord.js";
+import { base } from "./base";
+import { errorFollowUp } from "./util/errorFollowUp";
+
+const getDmPollStatus = (poll: DMPoll) => {
+  if (poll.startedAt && poll.finishedAt) {
+    return "zakończono";
+  }
+  if (poll.startedAt && !poll.finishedAt) {
+    return "w trakcie";
+  }
+  if (!poll.startedAt && !poll.finishedAt) {
+    return "nie rozpoczęto";
+  }
+  return "błędny status";
+};
+
+export const dmVoting = new Hashira({ name: "dmVoting" })
+  .use(base)
+  .group("glosowanie-dm", (group) =>
+    group
+      .setDescription("Głosowania w wiadomościach prywatnych")
+      .setDMPermission(false)
+      .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
+      .addCommand("utworz", (command) =>
+        command
+          .setDescription("Utwórz nowe głosowanie")
+          .handle(async ({ prisma }, _params, itx) => {
+            if (!itx.inCachedGuild()) return;
+
+            const rows = [
+              new ActionRowBuilder<ModalActionRowComponentBuilder>().setComponents(
+                new TextInputBuilder()
+                  .setCustomId("title")
+                  .setLabel("Nazwa (dla administracji)")
+                  .setPlaceholder("Głosowanie na Użytkownika Miesiąca")
+                  .setRequired(true)
+                  .setMinLength(2)
+                  .setMaxLength(50)
+                  .setStyle(TextInputStyle.Short),
+              ),
+              new ActionRowBuilder<ModalActionRowComponentBuilder>().setComponents(
+                new TextInputBuilder()
+                  .setCustomId("content")
+                  .setLabel("Treść (dla użytkownika)")
+                  .setPlaceholder("Kto powinien zostać Użytkownikiem Miesiąca?")
+                  .setRequired(true)
+                  .setMinLength(10)
+                  .setMaxLength(1024)
+                  .setStyle(TextInputStyle.Paragraph),
+              ),
+              new ActionRowBuilder<ModalActionRowComponentBuilder>().setComponents(
+                new TextInputBuilder()
+                  .setCustomId("options")
+                  .setLabel("Opcje (oddzielone nowymi liniami)")
+                  .setPlaceholder("Użytkownik 1\nUżytkownik 2\nUżytkownik 3")
+                  .setRequired(true)
+                  .setMinLength(2)
+                  .setMaxLength(256)
+                  .setStyle(TextInputStyle.Paragraph),
+              ),
+            ];
+            const modal = new ModalBuilder()
+              .setCustomId(`new-poll-${itx.user.id}`)
+              .setTitle("Nowe głosowanie")
+              .addComponents(...rows);
+            await itx.showModal(modal);
+
+            const submitAction = await itx.awaitModalSubmit({ time: 60_000 * 10 });
+            await submitAction.deferReply();
+
+            // TODO)) Abstract this into a helper/common util
+            const title = submitAction.components
+              .at(0)
+              ?.components.find((c) => c.customId === "title")?.value;
+            const content = submitAction.components
+              .at(1)
+              ?.components.find((c) => c.customId === "content")?.value;
+            const rawOptions = submitAction.components
+              .at(2)
+              ?.components.find((c) => c.customId === "options")?.value;
+            if (!title || !content || !rawOptions) {
+              return await errorFollowUp(
+                submitAction,
+                "Nie podano wszystkich wymaganych danych!",
+              );
+            }
+
+            const options = rawOptions.split("\n").map((option) => option.trim());
+
+            const poll = await prisma.dMPoll.create({
+              data: {
+                createdById: itx.user.id,
+                title,
+                content,
+                options: {
+                  createMany: {
+                    data: options.map((option) => ({ option })),
+                  },
+                },
+              },
+            });
+
+            await submitAction.editReply(
+              `Utworzono głosowanie ${italic(poll.title)} z ${bold(options.length.toString())} opcjami.`,
+            );
+          }),
+      )
+      .addCommand("lista", (command) =>
+        command
+          .setDescription("Wyświetl listę głosowań")
+          .handle(async ({ prisma }, _params, itx) => {
+            if (!itx.inCachedGuild()) return;
+
+            const paginator = new DatabasePaginator(
+              (props, createdAt) =>
+                prisma.dMPoll.findMany({
+                  ...props,
+                  orderBy: { createdAt },
+                  include: { options: true },
+                }),
+              () => prisma.dMPoll.count(),
+              { pageSize: 1, defaultOrder: PaginatorOrder.DESC },
+            );
+
+            const formatPoll = (
+              poll: DMPoll & { options: DMPollOption[] },
+              _idx: number,
+            ) => {
+              const lines = [`### ${poll.title} [${getDmPollStatus(poll)}]`];
+              if (poll.startedAt) {
+                lines.push(
+                  `**Rozpoczęto**: ${time(poll.startedAt, TimestampStyles.ShortDateTime)}`,
+                );
+              }
+              if (poll.finishedAt) {
+                lines.push(
+                  `**Zakończono**: ${time(poll.finishedAt, TimestampStyles.ShortDateTime)}`,
+                );
+              }
+              lines.push(
+                `**Opcje (${poll.options.length.toString()})**: ${poll.options.map((o) => o.option).join(", ")}`,
+              );
+              lines.push(`**Treść**: ${italic(poll.content)}`);
+              return lines.join("\n");
+            };
+
+            const view = new PaginatedView(
+              paginator,
+              "Głosowania DM",
+              formatPoll,
+              true,
+            );
+            await view.render(itx);
+          }),
+      ),
+  );

--- a/apps/bot/src/dmVoting.ts
+++ b/apps/bot/src/dmVoting.ts
@@ -435,7 +435,24 @@ export const dmVoting = new Hashira({ name: "dmVoting" })
           include: { poll: true },
         });
         if (!option) {
-          console.error("Invalid optionId for vote-option button:", optionId, "user:");
+          console.error("Invalid optionId for vote-option button:", optionId);
+          await itx.editReply("Coś poszło nie tak...");
+          return;
+        }
+
+        const participant = await tx.dMPollParticipant.findFirst({
+          where: {
+            userId: itx.user.id,
+            poll: { options: { some: { id: optionId } } },
+          },
+        });
+        if (!participant) {
+          console.error(
+            "User is not a participant in the poll:",
+            itx.user.id,
+            "optionId:",
+            optionId,
+          );
           await itx.editReply("Coś poszło nie tak...");
           return;
         }

--- a/apps/bot/src/dmVoting.ts
+++ b/apps/bot/src/dmVoting.ts
@@ -43,7 +43,7 @@ const getPollCreateOrUpdateActionRows = (poll: DMPollWithOptions | null = null) 
 
   const optionsInput = new TextInputBuilder()
     .setCustomId("options")
-    .setLabel("Opcje (oddzielone nowymi liniami)")
+    .setLabel("Opcje (oddzielone nowymi liniami, max. 5)")
     .setPlaceholder("Użytkownik 1\nUżytkownik 2\nUżytkownik 3")
     .setRequired(true)
     .setMinLength(2)
@@ -115,6 +115,12 @@ export const dmVoting = new Hashira({ name: "dmVoting" })
             }
 
             const options = rawOptions.split("\n").map((option) => option.trim());
+            if (options.length > 5) {
+              return await errorFollowUp(
+                submitAction,
+                "Podano za dużo opcji. Maksymalna liczba opcji to 5.",
+              );
+            }
 
             const poll = await prisma.dMPoll.create({
               data: {
@@ -182,6 +188,12 @@ export const dmVoting = new Hashira({ name: "dmVoting" })
             }
 
             const options = rawOptions.split("\n").map((option) => option.trim());
+            if (options.length > 5) {
+              return await errorFollowUp(
+                submitAction,
+                "Podano za dużo opcji. Maksymalna liczba opcji to 5.",
+              );
+            }
 
             await prisma.dMPoll.update({
               where: { id },
@@ -278,7 +290,6 @@ export const dmVoting = new Hashira({ name: "dmVoting" })
               );
             }
 
-            // FIXME)) Max buttons per action row is 5 - split them
             const buttons = poll.options.map((option) =>
               new ButtonBuilder()
                 .setLabel(option.option)

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -7,6 +7,7 @@ import { avatar } from "./avatar";
 import { base } from "./base";
 import { brochure } from "./brochure";
 import { dmForwarding } from "./dmForwarding";
+import { dmVoting } from "./dmVoting";
 import { economy } from "./economy";
 import { emojiCounting } from "./emojiCounting";
 import { guildAvailability } from "./guildAvailability";
@@ -52,6 +53,7 @@ export const bot = new Hashira({ name: "bot" })
   .use(userComplaint)
   .use(inviteManagement)
   .use(ultimatum)
+  .use(dmVoting)
   .handle("ready", async () => {
     // TODO)) Use a proper logger
     console.log("Bot is ready");

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   app:
     build: .

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "prisma-check-migrations": "bun run --cwd packages/db prisma-check-migrations",
     "prisma-migrate-dev": "bun run --cwd packages/db prisma migrate dev",
     "prisma-migrate-deploy": "bun run --cwd packages/db prisma migrate deploy",
-    "prisma-migrate-create": "bun run --cwd packages/db prisma migrate create",
     "prisma-push": "bun run --cwd packages/db prisma-push",
     "drop": "bun run --cwd packages/db drop",
     "test:core": "bun run --cwd packages/core test",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -12,7 +12,6 @@
     "prisma-studio": "prisma studio",
     "prisma-generate": "prisma generate",
     "prisma-migrate": "prisma migrate dev",
-    "prisma-migrate-create": "prisma migrate create",
     "prisma-push": "prisma db push",
     "prisma-check-migrations": "prisma migrate deploy && prisma migrate diff --exit-code --from-schema-datamodel ./prisma/schema.prisma --to-schema-datasource ./prisma/schema.prisma",
     "test": "bun test --preload ./test/preload.ts test/"

--- a/packages/db/prisma/migrations/20241027101044_add_dm_poll_models/migration.sql
+++ b/packages/db/prisma/migrations/20241027101044_add_dm_poll_models/migration.sql
@@ -1,0 +1,62 @@
+-- CreateTable
+CREATE TABLE "DmPoll" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "startedAt" TIMESTAMP(3),
+    "finishedAt" TIMESTAMP(3),
+    "createdById" TEXT NOT NULL,
+    "title" TEXT NOT NULL,
+    "content" TEXT NOT NULL,
+
+    CONSTRAINT "DmPoll_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DmPollOption" (
+    "id" SERIAL NOT NULL,
+    "pollId" INTEGER NOT NULL,
+    "option" TEXT NOT NULL,
+
+    CONSTRAINT "DmPollOption_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "DmPollParticipant" (
+    "pollId" INTEGER NOT NULL,
+    "userId" TEXT NOT NULL,
+    "messageId" TEXT,
+
+    CONSTRAINT "DmPollParticipant_pkey" PRIMARY KEY ("pollId","userId")
+);
+
+-- CreateTable
+CREATE TABLE "DmPollVote" (
+    "userId" TEXT NOT NULL,
+    "optionId" INTEGER NOT NULL,
+
+    CONSTRAINT "DmPollVote_pkey" PRIMARY KEY ("userId","optionId")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DmPollParticipant_pollId_userId_key" ON "DmPollParticipant"("pollId", "userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "DmPollVote_userId_optionId_key" ON "DmPollVote"("userId", "optionId");
+
+-- AddForeignKey
+ALTER TABLE "DmPoll" ADD CONSTRAINT "DmPoll_createdById_fkey" FOREIGN KEY ("createdById") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DmPollOption" ADD CONSTRAINT "DmPollOption_pollId_fkey" FOREIGN KEY ("pollId") REFERENCES "DmPoll"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DmPollParticipant" ADD CONSTRAINT "DmPollParticipant_pollId_fkey" FOREIGN KEY ("pollId") REFERENCES "DmPoll"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DmPollParticipant" ADD CONSTRAINT "DmPollParticipant_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DmPollVote" ADD CONSTRAINT "DmPollVote_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "DmPollVote" ADD CONSTRAINT "DmPollVote_optionId_fkey" FOREIGN KEY ("optionId") REFERENCES "DmPollOption"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -269,6 +269,7 @@ model User {
   receivedWarns                     Warn[]                             @relation("warn_userIdTousers")
   ultimatums                        Ultimatum[]
   dmPolls                           DMPoll[]
+  dmPollVotes                       DMPollVote[]
 
   // what's this?
   other_users User[] @relation("usersTousers")
@@ -360,7 +361,17 @@ model DMPollOption {
   pollId Int
   option String
 
-  poll DMPoll @relation(fields: [pollId], references: [id])
+  poll  DMPoll       @relation(fields: [pollId], references: [id])
+  votes DMPollVote[]
+}
+
+model DMPollVote {
+  id       Int    @id @default(autoincrement())
+  userId   String
+  optionId Int
+
+  user   User         @relation(fields: [userId], references: [id])
+  option DMPollOption @relation(fields: [optionId], references: [id])
 }
 
 enum EntryType {

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -270,6 +270,7 @@ model User {
   ultimatums                        Ultimatum[]
   dmPolls                           DMPoll[]
   dmPollVotes                       DMPollVote[]
+  participatingInDmPolls            DMPollParticipant[]
 
   // what's this?
   other_users User[] @relation("usersTousers")
@@ -352,8 +353,9 @@ model DMPoll {
   title       String
   content     String
 
-  createdBy User           @relation(fields: [createdById], references: [id])
-  options   DMPollOption[]
+  createdBy    User                @relation(fields: [createdById], references: [id])
+  options      DMPollOption[]
+  participants DMPollParticipant[]
 }
 
 model DMPollOption {
@@ -365,13 +367,26 @@ model DMPollOption {
   votes DMPollVote[]
 }
 
+model DMPollParticipant {
+  pollId Int
+  userId String
+
+  poll DMPoll @relation(fields: [pollId], references: [id])
+  user User   @relation(fields: [userId], references: [id])
+
+  @@id([pollId, userId])
+  @@unique([pollId, userId])
+}
+
 model DMPollVote {
-  id       Int    @id @default(autoincrement())
   userId   String
   optionId Int
 
   user   User         @relation(fields: [userId], references: [id])
   option DMPollOption @relation(fields: [optionId], references: [id])
+
+  @@id([userId, optionId])
+  @@unique([userId, optionId])
 }
 
 enum EntryType {

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -268,9 +268,9 @@ model User {
   givenWarns                        Warn[]                             @relation("warn_moderatorIdTousers")
   receivedWarns                     Warn[]                             @relation("warn_userIdTousers")
   ultimatums                        Ultimatum[]
-  dmPolls                           DMPoll[]
-  dmPollVotes                       DMPollVote[]
-  participatingInDmPolls            DMPollParticipant[]
+  dmPolls                           DmPoll[]
+  dmPollVotes                       DmPollVote[]
+  participatingInDmPolls            DmPollParticipant[]
 
   // what's this?
   other_users User[] @relation("usersTousers")
@@ -344,7 +344,7 @@ model Ultimatum {
   user      User      @relation(fields: [userId], references: [id])
 }
 
-model DMPoll {
+model DmPoll {
   id          Int       @id @default(autoincrement())
   createdAt   DateTime  @default(now())
   startedAt   DateTime?
@@ -354,37 +354,37 @@ model DMPoll {
   content     String
 
   createdBy    User                @relation(fields: [createdById], references: [id])
-  options      DMPollOption[]
-  participants DMPollParticipant[]
+  options      DmPollOption[]
+  participants DmPollParticipant[]
 }
 
-model DMPollOption {
+model DmPollOption {
   id     Int    @id @default(autoincrement())
   pollId Int
   option String
 
-  poll  DMPoll       @relation(fields: [pollId], references: [id])
-  votes DMPollVote[]
+  poll  DmPoll       @relation(fields: [pollId], references: [id])
+  votes DmPollVote[]
 }
 
-model DMPollParticipant {
+model DmPollParticipant {
   pollId    Int
   userId    String
   messageId String?
 
-  poll DMPoll @relation(fields: [pollId], references: [id])
+  poll DmPoll @relation(fields: [pollId], references: [id])
   user User   @relation(fields: [userId], references: [id])
 
   @@id([pollId, userId])
   @@unique([pollId, userId])
 }
 
-model DMPollVote {
+model DmPollVote {
   userId   String
   optionId Int
 
   user   User         @relation(fields: [userId], references: [id])
-  option DMPollOption @relation(fields: [optionId], references: [id])
+  option DmPollOption @relation(fields: [optionId], references: [id])
 
   @@id([userId, optionId])
   @@unique([userId, optionId])

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -268,6 +268,7 @@ model User {
   givenWarns                        Warn[]                             @relation("warn_moderatorIdTousers")
   receivedWarns                     Warn[]                             @relation("warn_userIdTousers")
   ultimatums                        Ultimatum[]
+  dmPolls                           DMPoll[]
 
   // what's this?
   other_users User[] @relation("usersTousers")
@@ -339,6 +340,27 @@ model Ultimatum {
   reason    String
   guild     Guild     @relation(fields: [guildId], references: [id])
   user      User      @relation(fields: [userId], references: [id])
+}
+
+model DMPoll {
+  id          Int       @id @default(autoincrement())
+  createdAt   DateTime  @default(now())
+  startedAt   DateTime?
+  finishedAt  DateTime?
+  createdById String
+  title       String
+  content     String
+
+  createdBy User           @relation(fields: [createdById], references: [id])
+  options   DMPollOption[]
+}
+
+model DMPollOption {
+  id     Int    @id @default(autoincrement())
+  pollId Int
+  option String
+
+  poll DMPoll @relation(fields: [pollId], references: [id])
 }
 
 enum EntryType {

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -368,8 +368,9 @@ model DMPollOption {
 }
 
 model DMPollParticipant {
-  pollId Int
-  userId String
+  pollId    Int
+  userId    String
+  messageId String?
 
   poll DMPoll @relation(fields: [pollId], references: [id])
   user User   @relation(fields: [userId], references: [id])


### PR DESCRIPTION
Nowy moduł dmVoting z funkcjonalnością tworzenia, edytowania, rozsyłania oraz zbierania wyników z głosowań prowadzonych przez bota w prywatnych wiadomościach.

Zostaje jeden poważniejszy bug, który może sprawić że rozsyłanie ankiety za pomocą roli będzie problematyczne. Nie mamy możliwości pobrania wszystkich uczestników danej roli bez fetchowania **wszystkich** członków serwera. Domyślnie discord.js nie ma pełnego cache, więc istnieje szansa że jacyś użytkownicy w nim nie będą w momencie użycia komendy. Moglibyśmy rozwiązać ten problem na dwa sposoby:
- Załadować **wszystkich** userów do cache - to wiąże się z dłuższym czasem startu bota i większym użyciem pamięci, ale może pomóc z innymi ewentualnymi błędami które wynikają z cache (w innych funkcjach bota)
- Zmienić sposób wybierania członków do głosowania - np. lista ID użytkowników

Wybieranie przez listę ID mogłoby być całkiem proste, bo inne boty które mają pełny cache mogą dać nam taką listę bez większego problemu. Z drugiej strony - zamiast polegać na innym bocie możemy rozwiązać problem u podstaw u nas i załadować pełen cache. Podejrzewam że nie byłoby to nawet dużo ramu.

Closes #43