### PR TITLE
Handling timeoutów przy zbieraniu odpowiedzi z modali

### DIFF
--- a/apps/bot/src/dmVoting.ts
+++ b/apps/bot/src/dmVoting.ts
@@ -15,7 +15,6 @@ import {
   EmbedBuilder,
   type ModalActionRowComponentBuilder,
   ModalBuilder,
-  type ModalSubmitInteraction,
   PermissionFlagsBits,
   RESTJSONErrorCodes,
   TextInputBuilder,
@@ -33,7 +32,6 @@ import { ensureUserExists, ensureUsersExist } from "./util/ensureUsersExist";
 import { errorFollowUp } from "./util/errorFollowUp";
 import { fetchMembers } from "./util/fetchMembers";
 import { hastebin } from "./util/hastebin";
-import { isDiscordjsError } from "./util/isDiscordjsError";
 import { numberToEmoji } from "./util/numberToEmoji";
 import { parseUserMentions } from "./util/parseUsers";
 import { createPluralize } from "./util/pluralize";
@@ -134,17 +132,15 @@ export const dmVoting = new Hashira({ name: "dmVoting" })
               .addComponents(...getPollCreateOrUpdateActionRows());
             await itx.showModal(modal);
 
-            let submitAction: ModalSubmitInteraction<"cached"> | null = null;
-            try {
-              submitAction = await itx.awaitModalSubmit({
-                time: 60_000 * 10,
-                filter: (modal) => modal.customId === customId,
-              });
-            } catch (e) {
-              if (isDiscordjsError(e, DiscordjsErrorCodes.InteractionCollectorError))
-                return;
-              throw e;
-            }
+            const submitAction = await discordTry(
+              () =>
+                itx.awaitModalSubmit({
+                  time: 60_000 * 10,
+                  filter: (modal) => modal.customId === customId,
+                }),
+              [DiscordjsErrorCodes.InteractionCollectorError],
+              () => null,
+            );
             if (!submitAction) return;
 
             await submitAction.deferReply();
@@ -251,17 +247,16 @@ export const dmVoting = new Hashira({ name: "dmVoting" })
               .addComponents(...getPollCreateOrUpdateActionRows(poll));
             await itx.showModal(modal);
 
-            let submitAction: ModalSubmitInteraction<"cached">;
-            try {
-              submitAction = await itx.awaitModalSubmit({
-                time: 60_000 * 10,
-                filter: (modal) => modal.customId === customId,
-              });
-            } catch (e) {
-              if (isDiscordjsError(e, DiscordjsErrorCodes.InteractionCollectorError))
-                return;
-              throw e;
-            }
+            const submitAction = await discordTry(
+              () =>
+                itx.awaitModalSubmit({
+                  time: 60_000 * 10,
+                  filter: (modal) => modal.customId === customId,
+                }),
+              [DiscordjsErrorCodes.InteractionCollectorError],
+              () => null,
+            );
+            if (!submitAction) return;
 
             await submitAction.deferReply();
 

--- a/apps/bot/src/miscellaneous.ts
+++ b/apps/bot/src/miscellaneous.ts
@@ -380,6 +380,7 @@ export const miscellaneous = new Hashira({ name: "miscellaneous" })
               result = await fn(ctx, itx);
             } catch (error) {
               await responder({ content: `Error: ${error}`, flags: "Ephemeral" });
+              return;
             }
 
             const strVal =

--- a/apps/bot/src/util/discordTry.ts
+++ b/apps/bot/src/util/discordTry.ts
@@ -1,19 +1,29 @@
-import { DiscordAPIError, type RESTJSONErrorCodes } from "discord.js";
+import {
+  DiscordAPIError,
+  DiscordjsError,
+  type DiscordjsErrorCodes,
+  type RESTJSONErrorCodes,
+} from "discord.js";
 
-interface DiscordTryOptions {
+type ErrorCodes = (DiscordjsErrorCodes | RESTJSONErrorCodes)[];
+type DiscordError = DiscordjsError | DiscordAPIError;
+interface Options {
   rethrowAfterCatch?: boolean;
 }
 
 export async function discordTry<T, U>(
   fn: () => T,
-  codes: RESTJSONErrorCodes[],
-  catchFn: (e: DiscordAPIError) => U,
-  { rethrowAfterCatch }: DiscordTryOptions = {},
+  codes: ErrorCodes,
+  catchFn: (e: DiscordError) => U,
+  { rethrowAfterCatch }: Options = {},
 ): Promise<T | U> {
   try {
     return await fn();
   } catch (e) {
-    if (e instanceof DiscordAPIError && codes.some((code) => code === e.code)) {
+    if (
+      (e instanceof DiscordjsError || e instanceof DiscordAPIError) &&
+      codes.some((code) => code === e.code)
+    ) {
       const result = await catchFn(e);
       if (!rethrowAfterCatch) return result;
     }

--- a/apps/bot/src/util/isDiscordjsError.ts
+++ b/apps/bot/src/util/isDiscordjsError.ts
@@ -1,0 +1,6 @@
+import { DiscordjsError, type DiscordjsErrorCodes } from "discord.js";
+
+export const isDiscordjsError = (
+  e: unknown,
+  code: DiscordjsErrorCodes,
+): e is DiscordjsError => e instanceof DiscordjsError && e.code === code;

--- a/apps/bot/src/util/isDiscordjsError.ts
+++ b/apps/bot/src/util/isDiscordjsError.ts
@@ -1,6 +1,0 @@
-import { DiscordjsError, type DiscordjsErrorCodes } from "discord.js";
-
-export const isDiscordjsError = (
-  e: unknown,
-  code: DiscordjsErrorCodes,
-): e is DiscordjsError => e instanceof DiscordjsError && e.code === code;


### PR DESCRIPTION
`InteractionCollectorError` jest rzucany kiedy modal nie otrzyma odpowiedzi, wiec dodałem handling żeby niewypełnienie go nie kończyło się błędem.

Powinno naprawić https://strata-czasu.sentry.io/issues/7899485/

Przy okazji naprawiłem buga w `/misc eval` z podwójnymi odpowiedziami: https://strata-czasu.sentry.io/issues/28574037/