### PR TITLE
Bot healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,3 +28,6 @@ RUN bun prisma-generate
 
 USER bun
 CMD ["bun", "start:prod"]
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
+  CMD bun run healthcheck || exit 1

--- a/apps/bot/healthcheck.ts
+++ b/apps/bot/healthcheck.ts
@@ -1,0 +1,24 @@
+import { differenceInSeconds } from "date-fns";
+import { readHealthCheck } from "./src/healthcheck.ts";
+
+const TIMEOUT_SECONDS = 65;
+
+if (import.meta.main) {
+  const healthData = await readHealthCheck();
+  if (healthData) {
+    console.log("Health Check Data:", healthData);
+  } else {
+    console.error("Failed to read health check data.");
+    process.exit(1);
+  }
+
+  const diffSeconds = differenceInSeconds(new Date(), new Date(healthData.timestamp));
+  if (diffSeconds > TIMEOUT_SECONDS) {
+    console.error(`Health check timeout. Seconds since last heartbeat: ${diffSeconds}`);
+    process.exit(1);
+  } else {
+    console.log(
+      `Health check successful. Seconds since last heartbeat: ${diffSeconds}`,
+    );
+  }
+}

--- a/apps/bot/src/healthcheck.ts
+++ b/apps/bot/src/healthcheck.ts
@@ -1,0 +1,31 @@
+const FILENAME = "/tmp/bot_healthcheck.json";
+
+type HealthCheckData = {
+  pid: number;
+  uptime: number;
+  timestamp: string;
+};
+
+export async function writeHealthCheck() {
+  const healthData: HealthCheckData = {
+    pid: process.pid,
+    uptime: process.uptime(),
+    timestamp: new Date().toISOString(),
+  };
+
+  try {
+    await Bun.write(FILENAME, JSON.stringify(healthData, null, 2));
+  } catch (error) {
+    console.error(`Failed to write health check: ${error}`);
+  }
+}
+
+export async function readHealthCheck() {
+  try {
+    const data = await Bun.file(FILENAME).json();
+    return data as HealthCheckData;
+  } catch (error) {
+    console.error(`Failed to read health check: ${error}`);
+    return null;
+  }
+}

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -12,6 +12,7 @@ import { dmVoting } from "./dmVoting";
 import { economy } from "./economy";
 import { emojiCounting } from "./emojiCounting/emojiCounting";
 import { guildAvailability } from "./guildAvailability";
+import { writeHealthCheck } from "./healthcheck";
 import { inviteManagement } from "./inviteManagement";
 import { discordEventLogging } from "./logging/discordEventLogging";
 import { massDM } from "./massDM";
@@ -71,6 +72,7 @@ export const bot = new Hashira({ name: "bot" })
   .use(massDM)
   .handle("ready", async () => {
     console.log("Bot is ready!");
+    setInterval(writeHealthCheck, 1000 * 60);
   });
 
 if (import.meta.main) {

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -72,7 +72,8 @@ export const bot = new Hashira({ name: "bot" })
   .use(massDM)
   .handle("ready", async () => {
     console.log("Bot is ready!");
-    setInterval(writeHealthCheck, 1000 * 60);
+    await writeHealthCheck(); // Initial write on startup
+    setInterval(writeHealthCheck, 1000 * 60); // Write heartbeat every minute
   });
 
 if (import.meta.main) {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "fix": "biome check --write",
     "start": "bun run --cwd apps/bot start",
     "start:prod": "bun prisma-migrate-deploy && bun seed --production && bun run --cwd apps/bot start",
+    "healthcheck": "bun run --cwd apps/bot healthcheck",
     "prisma-studio": "bun run --cwd packages/db prisma-studio",
     "prisma-generate": "bun run --cwd packages/db prisma generate",
     "prisma-check-migrations": "bun run --cwd packages/db prisma-check-migrations",


### PR DESCRIPTION
Had an idea to implement a simple healtcheck without relying on http/webservers.

1. Write a heartbeat with a timestamp to a `/tmp/bot_healthcheck.json` file
2. Check every n seconds (currently 30) if the heartbeat timestamp is under 60s (+5s of leeway) before the current time
3. If heartbeat is fresh enough, assume healthy
4. If it's older than 60+5s, assume unhealthy (`setInterval` in bot's `ready` handler died)

Do you see any issues with this @HKGx? Maybe multiple setInterval loops being spun up on re-fires of the `ready` event? I'm not sure if that can happen in discord.js.