### PR TITLE
fix(dmVoting): Put failed poll sends into a hastebin URL if too long

### DIFF
--- a/apps/bot/src/dmVoting.ts
+++ b/apps/bot/src/dmVoting.ts
@@ -632,10 +632,22 @@ export const dmVoting = new Hashira({ name: "dmVoting" })
                 (m) => m.messageId === null,
               );
               lines.push(
-                `Nie udało się wysłać wiadomości do:\n${failedToSendMessages
-                  .map(({ member }) => `${member.user.tag} ${member.user.id}`)
-                  .join("\n")}`,
+                `Nie udało się wysłać wiadomości do ${failedToSendMessages.length} użytkowników:`,
               );
+              if (failedToSendMessages.length <= 20) {
+                lines.push(
+                  failedToSendMessages
+                    .map(({ member }) => `${member.user.tag} ${member.user.id}`)
+                    .join("\n"),
+                );
+              } else {
+                const failedToSendMembersHastebinUrl = await hastebin(
+                  failedToSendMessages
+                    .map(({ member }) => `${member.user.tag} ${member.user.id}`)
+                    .join("\n"),
+                );
+                lines.push(failedToSendMembersHastebinUrl);
+              }
             }
 
             await itx.user.createDM();


### PR DESCRIPTION
Quick fix for the DM poll message where it tells the creator how much failed sends it had. It was overflowing the max message length, so I made a hard cap of 20 entries before uploading the list to a hastebin paste.

Creating via PR because I don't want to restart the bot right now.