### PR TITLE
Always update `endedAt` when an ultimatum ends

### DIFF
--- a/apps/bot/src/messageQueueBase.ts
+++ b/apps/bot/src/messageQueueBase.ts
@@ -59,15 +59,18 @@ export const messageQueueBase = new Hashira({ name: "messageQueueBase" })
             const currentUltimatum = await prisma.ultimatum.findFirst({
               where: { userId, guildId, endedAt: null },
             });
-
             if (!currentUltimatum) return;
+
+            const updatedUltimatum = await prisma.ultimatum.update({
+              where: { id: currentUltimatum.id },
+              data: { endedAt: new Date() },
+            });
 
             const guild = await discordTry(
               async () => client.guilds.fetch(guildId),
               [RESTJSONErrorCodes.UnknownGuild],
               async () => null,
             );
-
             if (!guild) return;
 
             const member = await discordTry(
@@ -75,15 +78,9 @@ export const messageQueueBase = new Hashira({ name: "messageQueueBase" })
               [RESTJSONErrorCodes.UnknownMember],
               async () => null,
             );
-
             if (!member) return;
 
             await member.roles.remove(STRATA_CZASU.ULTIMATUM_ROLE, "Koniec ultimatum");
-
-            const updatedUltimatum = await prisma.ultimatum.update({
-              where: { id: currentUltimatum.id },
-              data: { endedAt: new Date() },
-            });
 
             await sendDirectMessage(
               member.user,


### PR DESCRIPTION
This makes the ultimatum be marked as "ended" in our DB, even when the user isn't in the guild at the time it ends.

This is a little confusing in terms of logging, becase we'll remove the ultimatum without logging anything, but it's better to have an ultimatum marked as done in the DB than to keep indefinitely.

Fixes #133