### PR TITLE
Fix reorder

### DIFF
--- a/packages/paginate/src/index.ts
+++ b/packages/paginate/src/index.ts
@@ -74,9 +74,11 @@ export class StaticPaginator<T> implements Paginator<T> {
   }
 
   async reorder(orderBy?: PaginatorOrder): Promise<T[]> {
-    if (orderBy) this.#ordering = orderBy;
-    else this.#ordering = toggleOrder(this.#ordering);
-    this.#items.reverse();
+    const nextOrder = orderBy ?? toggleOrder(this.#ordering);
+    if (nextOrder !== this.#ordering) {
+      this.#items.reverse();
+    }
+    this.#ordering = nextOrder;
     this.#page = 0;
     return await this.current();
   }

--- a/packages/paginate/test/index.test.ts
+++ b/packages/paginate/test/index.test.ts
@@ -43,6 +43,17 @@ describe("StaticPaginator", () => {
     expect(await paginator.current()).toEqual([1, 2, 3]);
   });
 
+  it("should not reorder when the same ordering is provided", async () => {
+    const paginator = new StaticPaginator({ items, pageSize });
+
+    const first = await paginator.current();
+    await paginator.reorder(PaginatorOrder.ASC);
+    const second = await paginator.current();
+
+    expect(second).toEqual(first);
+    expect(paginator.displayCurrentPage).toBe("1");
+  });
+
   it("should navigate to the next page", async () => {
     const paginator = new StaticPaginator({ items, pageSize });
 


### PR DESCRIPTION
## Summary
- handle same ordering in paginator.reorder
- test that reorder doesn't shuffle when the order is unchanged
- simplify reorder to remove duplicated property assignments

## Testing
- `bun test packages/paginate/test/index.test.ts`
- `bun test`

------
https://chatgpt.com/codex/tasks/task_e_683f4447e9ac8328bddaf04afb91ba80