### PR TITLE
Per-guild items

### DIFF
--- a/apps/bot/seed.ts
+++ b/apps/bot/seed.ts
@@ -27,8 +27,7 @@ const createDefaultStrataCzasuCurrency = async (guildId: string) => {
   });
 };
 
-// FIXME)) Run this for each guild once items are per-guild
-const createDefaultItems = async () => {
+const createDefaultItems = async (guildId: string) => {
   const existingItems = await prisma.item.findMany({
     where: { type: { in: DEFAULT_ITEMS.map((it) => it.type) } },
   });
@@ -41,6 +40,7 @@ const createDefaultItems = async () => {
     await prisma.item.create({
       data: {
         ...item,
+        guildId,
         createdBy: USER_IDS.Defous,
       },
     });
@@ -90,10 +90,10 @@ if (isProduction) {
   const testingServers = [GUILD_IDS.Homik, GUILD_IDS.Piwnica];
   for (const guildId of testingServers) {
     await createDefaultStrataCzasuCurrency(guildId);
+    await createDefaultItems(guildId);
     await setDefaultLogChannels(guildId);
     console.log(`Seeding completed for test guild ${guildId}`);
   }
-  await createDefaultItems();
 }
 
 console.log(`Seeding completed for ${isProduction ? "production" : "dev"} environment`);

--- a/apps/bot/src/economy/items.ts
+++ b/apps/bot/src/economy/items.ts
@@ -1,5 +1,5 @@
 import { Hashira, PaginatedView } from "@hashira/core";
-import { DatabasePaginator, type Item } from "@hashira/db";
+import { DatabasePaginator, type Item, type Prisma } from "@hashira/db";
 import { PermissionFlagsBits, bold, inlineCode, italic } from "discord.js";
 import { base } from "../base";
 import { STRATA_CZASU_CURRENCY } from "../specializedConstants";
@@ -29,7 +29,10 @@ export const items = new Hashira({ name: "items" })
             if (!itx.inCachedGuild()) return;
             await itx.deferReply();
 
-            const where = { deletedAt: null };
+            const where: Prisma.ItemWhereInput = {
+              deletedAt: null,
+              guildId: itx.guildId,
+            };
 
             const paginator = new DatabasePaginator(
               (props) => prisma.item.findMany({ where, ...props }),
@@ -66,10 +69,11 @@ export const items = new Hashira({ name: "items" })
               await ensureUserExists(tx, itx.user);
               const item = await tx.item.create({
                 data: {
-                  name,
-                  description,
+                  guildId: itx.guildId,
                   createdBy: itx.user.id,
                   type: "item",
+                  name,
+                  description,
                 },
               });
 
@@ -111,6 +115,7 @@ export const items = new Hashira({ name: "items" })
               data: {
                 name,
                 description,
+                guildId: itx.guildId,
                 createdBy: itx.user.id,
                 type: "profileTitle",
               },
@@ -148,6 +153,7 @@ export const items = new Hashira({ name: "items" })
                 item: {
                   create: {
                     name,
+                    guildId: itx.guildId,
                     createdBy: itx.user.id,
                     type: "badge",
                   },
@@ -181,6 +187,7 @@ export const items = new Hashira({ name: "items" })
                 item: {
                   create: {
                     name,
+                    guildId: itx.guildId,
                     createdBy: itx.user.id,
                     type: "staticTintColor",
                   },
@@ -215,7 +222,7 @@ export const items = new Hashira({ name: "items" })
             }
 
             const item = await prisma.$transaction(async (tx) => {
-              const item = await getItem(tx, id);
+              const item = await getItem(tx, id, itx.guildId);
               if (!item) {
                 await errorFollowUp(itx, "Nie znaleziono przedmiotu o podanym ID");
                 return null;
@@ -245,7 +252,7 @@ export const items = new Hashira({ name: "items" })
             await itx.deferReply();
 
             const item = await prisma.$transaction(async (tx) => {
-              const item = await getItem(tx, id);
+              const item = await getItem(tx, id, itx.guildId);
               if (!item) {
                 await errorFollowUp(itx, "Nie znaleziono przedmiotu o podanym ID");
                 return null;

--- a/apps/bot/src/economy/shop.ts
+++ b/apps/bot/src/economy/shop.ts
@@ -84,10 +84,12 @@ export const shop = new Hashira({ name: "shop" })
               .setMinValue(1),
           )
           .autocomplete(async ({ prisma }, _, itx) => {
+            if (!itx.inCachedGuild()) return;
             const results = await prisma.shopItem.findMany({
               where: {
                 deletedAt: null,
                 item: {
+                  guildId: itx.guildId,
                   name: {
                     contains: itx.options.getFocused(),
                     mode: "insensitive",
@@ -112,7 +114,7 @@ export const shop = new Hashira({ name: "shop" })
             const amount = rawAmount ?? 1;
 
             const success = await prisma.$transaction(async (tx) => {
-              const shopItem = await getShopItem(tx, id);
+              const shopItem = await getShopItem(tx, id, itx.guildId);
               if (!shopItem) {
                 await errorFollowUp(
                   itx,
@@ -176,7 +178,7 @@ export const shop = new Hashira({ name: "shop" })
             if (!itx.inCachedGuild()) return;
             await itx.deferReply();
 
-            const item = await getItem(prisma, id);
+            const item = await getItem(prisma, id, itx.guildId);
             if (!item) {
               await errorFollowUp(itx, "Nie znaleziono przedmiotu o podanym ID");
               return;
@@ -203,7 +205,7 @@ export const shop = new Hashira({ name: "shop" })
             if (!itx.inCachedGuild()) return;
             await itx.deferReply();
 
-            const shopItem = await getShopItem(prisma, id);
+            const shopItem = await getShopItem(prisma, id, itx.guildId);
             if (!shopItem) {
               await errorFollowUp(
                 itx,
@@ -229,7 +231,7 @@ export const shop = new Hashira({ name: "shop" })
             if (!itx.inCachedGuild()) return;
             await itx.deferReply();
 
-            const shopItem = await getShopItem(prisma, id);
+            const shopItem = await getShopItem(prisma, id, itx.guildId);
             if (!shopItem) {
               await errorFollowUp(
                 itx,

--- a/apps/bot/src/economy/util.ts
+++ b/apps/bot/src/economy/util.ts
@@ -5,19 +5,25 @@ export type GetCurrencyConditionOptions =
   | { currencySymbol: string }
   | { currencyId: number };
 
-export const getItem = (prisma: PrismaTransaction, id: number) =>
+export const getItem = (prisma: PrismaTransaction, id: number, guildId: string) =>
   prisma.item.findFirst({
     where: {
       id,
       deletedAt: null,
+      guildId,
     },
   });
 
-export const getShopItem = async (prisma: PrismaTransaction, id: number) =>
+export const getShopItem = async (
+  prisma: PrismaTransaction,
+  id: number,
+  guildId: string,
+) =>
   prisma.shopItem.findFirst({
     where: {
       id,
       deletedAt: null,
+      item: { guildId },
     },
     include: {
       item: true,
@@ -27,6 +33,7 @@ export const getShopItem = async (prisma: PrismaTransaction, id: number) =>
 export const getInventoryItem = async (
   prisma: PrismaTransaction,
   itemId: number,
+  guildId: string,
   userId: string,
 ) =>
   prisma.inventoryItem.findFirst({
@@ -34,6 +41,7 @@ export const getInventoryItem = async (
       itemId,
       userId,
       deletedAt: null,
+      item: { guildId },
     },
   });
 

--- a/apps/bot/src/profile/index.ts
+++ b/apps/bot/src/profile/index.ts
@@ -38,12 +38,17 @@ async function fetchAsBuffer(url: string | URL) {
   return Buffer.from(arrbuf);
 }
 
-async function getUserAccesses(prisma: BaseContext["prisma"], userId: string) {
+async function getUserAccesses(
+  prisma: BaseContext["prisma"],
+  guildId: string,
+  userId: string,
+) {
   const ownedItems = await prisma.inventoryItem.findMany({
     where: {
       userId,
       deletedAt: null,
       item: {
+        guildId,
         type: {
           in: ["dynamicTintColorAccess", "customTintColorAccess"],
         },
@@ -277,7 +282,7 @@ export const profile = new Hashira({ name: "profile" })
                 if (!itx.inCachedGuild()) return;
 
                 const where: Prisma.InventoryItemWhereInput = {
-                  item: { type: "profileTitle" },
+                  item: { guildId: itx.guildId, type: "profileTitle" },
                   userId: itx.user.id,
                   deletedAt: null,
                 };
@@ -308,11 +313,13 @@ export const profile = new Hashira({ name: "profile" })
                 command.setDescription("Tytuł").setAutocomplete(true),
               )
               .autocomplete(async ({ prisma }, _, itx) => {
+                if (!itx.inCachedGuild()) return;
                 const results = await prisma.inventoryItem.findMany({
                   where: {
                     userId: itx.user.id,
                     deletedAt: null,
                     item: {
+                      guildId: itx.guildId,
                       type: "profileTitle",
                       name: {
                         contains: itx.options.getFocused(),
@@ -332,7 +339,11 @@ export const profile = new Hashira({ name: "profile" })
 
                 const ownedTitle = await prisma.inventoryItem.findFirst({
                   where: {
-                    item: { id, type: "profileTitle" },
+                    item: {
+                      id,
+                      guildId: itx.guildId,
+                      type: "profileTitle",
+                    },
                     userId: itx.user.id,
                     deletedAt: null,
                   },
@@ -369,7 +380,7 @@ export const profile = new Hashira({ name: "profile" })
                 if (!itx.inCachedGuild()) return;
 
                 const where: Prisma.InventoryItemWhereInput = {
-                  item: { type: "badge" },
+                  item: { guildId: itx.guildId, type: "badge" },
                   userId: itx.user.id,
                   deletedAt: null,
                 };
@@ -412,11 +423,13 @@ export const profile = new Hashira({ name: "profile" })
                 id.setDescription("Odznaka").setAutocomplete(true),
               )
               .autocomplete(async ({ prisma }, _, itx) => {
+                if (!itx.inCachedGuild()) return;
                 const results = await prisma.inventoryItem.findMany({
                   where: {
                     userId: itx.user.id,
                     deletedAt: null,
                     item: {
+                      guildId: itx.guildId,
                       type: "badge",
                       name: {
                         contains: itx.options.getFocused(),
@@ -437,7 +450,11 @@ export const profile = new Hashira({ name: "profile" })
 
                   const ownedBadge = await prisma.inventoryItem.findFirst({
                     where: {
-                      item: { id, type: "badge" },
+                      item: {
+                        id,
+                        guildId: itx.guildId,
+                        type: "badge",
+                      },
                       userId: itx.user.id,
                       deletedAt: null,
                     },
@@ -523,7 +540,7 @@ export const profile = new Hashira({ name: "profile" })
                 await itx.deferReply();
 
                 const where: Prisma.InventoryItemWhereInput = {
-                  item: { type: "staticTintColor" },
+                  item: { guildId: itx.guildId, type: "staticTintColor" },
                   userId: itx.user.id,
                   deletedAt: null,
                 };
@@ -537,7 +554,11 @@ export const profile = new Hashira({ name: "profile" })
                   () => prisma.inventoryItem.count({ where }),
                 );
 
-                const accesses = await getUserAccesses(prisma, itx.user.id);
+                const accesses = await getUserAccesses(
+                  prisma,
+                  itx.guildId,
+                  itx.user.id,
+                );
                 const accessBadges: { name: string; access: boolean }[] = [
                   {
                     name: "Dynamiczny kolor z nicku",
@@ -596,11 +617,13 @@ export const profile = new Hashira({ name: "profile" })
                 id.setDescription("Przedmiot").setAutocomplete(true),
               )
               .autocomplete(async ({ prisma }, _, itx) => {
+                if (!itx.inCachedGuild()) return;
                 const results = await prisma.inventoryItem.findMany({
                   where: {
                     userId: itx.user.id,
                     deletedAt: null,
                     item: {
+                      guildId: itx.guildId,
                       type: "staticTintColor",
                       name: {
                         contains: itx.options.getFocused(),
@@ -621,7 +644,11 @@ export const profile = new Hashira({ name: "profile" })
 
                 const ownedColor = await prisma.inventoryItem.findFirst({
                   where: {
-                    item: { id, type: "staticTintColor" },
+                    item: {
+                      id,
+                      guildId: itx.guildId,
+                      type: "staticTintColor",
+                    },
                     userId: itx.user.id,
                     deletedAt: null,
                   },
@@ -671,7 +698,11 @@ export const profile = new Hashira({ name: "profile" })
                 await itx.deferReply();
 
                 await ensureUserExists(prisma, itx.user);
-                const accesses = await getUserAccesses(prisma, itx.user.id);
+                const accesses = await getUserAccesses(
+                  prisma,
+                  itx.guildId,
+                  itx.user.id,
+                );
                 const hasAccess = accesses.includes("dynamicTintColorAccess");
                 if (!hasAccess) {
                   return await errorFollowUp(
@@ -715,7 +746,11 @@ export const profile = new Hashira({ name: "profile" })
                 }
 
                 await ensureUserExists(prisma, itx.user);
-                const accesses = await getUserAccesses(prisma, itx.user.id);
+                const accesses = await getUserAccesses(
+                  prisma,
+                  itx.guildId,
+                  itx.user.id,
+                );
                 const hasAccess = accesses.includes("customTintColorAccess");
                 if (!hasAccess) {
                   return await errorFollowUp(

--- a/packages/db/prisma/migrations/20250704174958_add_guild_id_to_item/migration.sql
+++ b/packages/db/prisma/migrations/20250704174958_add_guild_id_to_item/migration.sql
@@ -1,0 +1,26 @@
+/*
+Generated steps:
+- AlterTable with new "guildId" not-null column
+- AddForeignKey
+
+Manual changes:
+- Removed not-null from first AlterTable
+- Force-insert a guild with id '211261411119202305' if it doesn't exist
+- Set the guild to all existing items
+- Restore not-null to "guildId"
+*/
+
+-- AlterTable
+ALTER TABLE "item" ADD COLUMN     "guildId" TEXT;
+
+-- Insert
+INSERT INTO "guild" ("id") VALUES ('211261411119202305') ON CONFLICT DO NOTHING;
+
+-- Update
+UPDATE "item" SET "guildId" = '211261411119202305' WHERE "guildId" IS NULL;
+
+-- AlterTable
+ALTER TABLE "item" ALTER COLUMN "guildId" SET NOT NULL;
+
+-- AddForeignKey
+ALTER TABLE "item" ADD CONSTRAINT "item_guildId_fkey" FOREIGN KEY ("guildId") REFERENCES "guild"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/db/prisma/models/economy.prisma
+++ b/packages/db/prisma/models/economy.prisma
@@ -1,0 +1,68 @@
+model Currency {
+  id        Int      @id(map: "core_currency_pkey") @default(autoincrement())
+  name      String
+  symbol    String
+  guildId   String
+  createdBy String
+  createdAt DateTime @default(now()) @db.Timestamp(6)
+
+  user                             User     @relation(fields: [createdBy], references: [id], onDelete: SetNull, onUpdate: NoAction, map: "currency_createdBy_users_id_fk")
+  guild                            Guild    @relation(fields: [guildId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "currency_guildId_guild_id_fk")
+  wallet_wallet_currencyTocurrency Wallet[] @relation("wallet_currencyTocurrency")
+
+  @@unique([guildId, name], map: "currency_guildId_name_unique")
+  @@unique([guildId, symbol], map: "currency_guildId_symbol_unique")
+  @@map("currency")
+}
+
+model Wallet {
+  id         Int      @id(map: "core_wallet_pkey") @default(autoincrement())
+  name       String
+  userId     String
+  currencyId Int      @map("currency")
+  default    Boolean  @default(false)
+  createdAt  DateTime @default(now()) @db.Timestamp(6)
+  guildId    String
+  balance    Int      @default(0)
+
+  relatedTransactions Transaction[] @relation("transaction_relatedWalletTowallet")
+  transactions        Transaction[] @relation("transaction_walletTowallet")
+  currency            Currency      @relation("wallet_currencyTocurrency", fields: [currencyId], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "wallet_currency_currency_id_fk")
+  guild               Guild         @relation(fields: [guildId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "wallet_guildId_guild_id_fk")
+  user                User          @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "wallet_userId_users_id_fk")
+
+  @@unique([userId, name, guildId], map: "wallet_userId_name_guildId_unique")
+  @@map("wallet")
+}
+
+model Transaction {
+  id              Int             @id(map: "core_transaction_pkey") @default(autoincrement())
+  walletId        Int             @map("wallet")
+  relatedWalletId Int?            @map("relatedWallet")
+  relatedUserId   String?
+  amount          Int
+  createdAt       DateTime        @default(now()) @db.Timestamp(6)
+  reason          String?
+  transactionType TransactionType
+  entryType       EntryType
+
+  relatedUser   User?   @relation(fields: [relatedUserId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "transaction_relatedUserId_users_id_fk")
+  relatedWallet Wallet? @relation("transaction_relatedWalletTowallet", fields: [relatedWalletId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "transaction_relatedWallet_wallet_id_fk")
+  wallet        Wallet  @relation("transaction_walletTowallet", fields: [walletId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "transaction_wallet_wallet_id_fk")
+
+  @@map("transaction")
+}
+
+enum EntryType {
+  debit
+  credit
+
+  @@map("entry_type")
+}
+
+enum TransactionType {
+  transfer
+  add
+
+  @@map("transaction_type")
+}

--- a/packages/db/prisma/models/items.prisma
+++ b/packages/db/prisma/models/items.prisma
@@ -1,0 +1,77 @@
+// TODO)) `canBeTraded` or something like that to limit trading of items.
+// For the time being, only type=`item` items are tradeable.
+// TODO)) Some items (like type=`profileTitle`) should be unique per user.
+// TODO)) Items should be guild-specific, along with all their relations!!!
+model Item {
+  id          Int       @id(map: "core_item_pkey") @default(autoincrement())
+  description String?
+  createdAt   DateTime  @default(now()) @db.Timestamp(6)
+  editedAt    DateTime? @db.Timestamp(6)
+  deletedAt   DateTime? @db.Timestamp(6)
+  createdBy   String
+  type        ItemType  @default(item)
+  name        String
+
+  inventoryItem   InventoryItem[]
+  creator         User              @relation(fields: [createdBy], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "item_createdBy_users_id_fk")
+  shopItem        ShopItem[]
+  profileSettings ProfileSettings[]
+  badge           Badge?
+  tintColor       TintColor?
+
+  @@map("item")
+}
+
+enum ItemType {
+  item
+  profileTitle
+  badge // Specifies `badge`
+  staticTintColor // Specifies `tintColor`
+  dynamicTintColorAccess
+  customTintColorAccess
+}
+
+model Badge {
+  id     Int   @id() @default(autoincrement())
+  itemId Int   @unique
+  image  Bytes // PNG binary data, 128x128px
+
+  item                Item                    @relation(fields: [itemId], references: [id])
+  displayedInProfiles DisplayedProfileBadge[]
+}
+
+model TintColor {
+  id     Int @id @default(autoincrement())
+  itemId Int @unique
+  color  Int
+
+  item           Item              @relation(fields: [itemId], references: [id])
+  usedInProfiles ProfileSettings[]
+}
+
+model ShopItem {
+  id        Int       @id(map: "core_shop_item_pkey") @default(autoincrement())
+  itemId    Int
+  price     Int
+  createdAt DateTime  @default(now()) @db.Timestamp(6)
+  editedAt  DateTime? @db.Timestamp(6)
+  deletedAt DateTime? @db.Timestamp(6)
+  createdBy String
+  creator   User      @relation(fields: [createdBy], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "shopItem_createdBy_users_id_fk")
+  item      Item      @relation(fields: [itemId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "shopItem_itemId_item_id_fk")
+
+  @@map("shopItem")
+}
+
+model InventoryItem {
+  id        Int       @id(map: "core_inventory_item_pkey") @default(autoincrement())
+  itemId    Int
+  userId    String
+  createdAt DateTime  @default(now()) @db.Timestamp(6)
+  deletedAt DateTime? @db.Timestamp(6)
+
+  item Item @relation(fields: [itemId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "inventoryItem_itemId_item_id_fk")
+  user User @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "inventoryItem_userId_users_id_fk")
+
+  @@map("inventoryItem")
+}

--- a/packages/db/prisma/models/items.prisma
+++ b/packages/db/prisma/models/items.prisma
@@ -1,23 +1,25 @@
 // TODO)) `canBeTraded` or something like that to limit trading of items.
 // For the time being, only type=`item` items are tradeable.
 // TODO)) Some items (like type=`profileTitle`) should be unique per user.
-// TODO)) Items should be guild-specific, along with all their relations!!!
 model Item {
-  id          Int       @id(map: "core_item_pkey") @default(autoincrement())
-  description String?
-  createdAt   DateTime  @default(now()) @db.Timestamp(6)
-  editedAt    DateTime? @db.Timestamp(6)
-  deletedAt   DateTime? @db.Timestamp(6)
-  createdBy   String
-  type        ItemType  @default(item)
-  name        String
+  id        Int       @id(map: "core_item_pkey") @default(autoincrement())
+  createdAt DateTime  @default(now()) @db.Timestamp(6)
+  editedAt  DateTime? @db.Timestamp(6)
+  deletedAt DateTime? @db.Timestamp(6)
+  guildId   String
+  createdBy String
 
-  inventoryItem   InventoryItem[]
+  type        ItemType @default(item)
+  name        String
+  description String?
+
+  guild           Guild             @relation(fields: [guildId], references: [id])
   creator         User              @relation(fields: [createdBy], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "item_createdBy_users_id_fk")
   shopItem        ShopItem[]
-  profileSettings ProfileSettings[]
+  inventoryItem   InventoryItem[]
   badge           Badge?
   tintColor       TintColor?
+  profileSettings ProfileSettings[]
 
   @@map("item")
 }

--- a/packages/db/prisma/models/moderation.prisma
+++ b/packages/db/prisma/models/moderation.prisma
@@ -1,0 +1,68 @@
+model Warn {
+  id           Int       @id(map: "core_warn_pkey") @default(autoincrement())
+  createdAt    DateTime  @default(now()) @db.Timestamp(6)
+  editedAt     DateTime? @db.Timestamp(6)
+  guildId      String
+  userId       String
+  moderatorId  String
+  reason       String
+  deletedAt    DateTime? @db.Timestamp(6)
+  deleteReason String?
+
+  guild     Guild @relation(fields: [guildId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "warn_guildId_guild_id_fk")
+  moderator User  @relation("warn_moderatorIdTousers", fields: [moderatorId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "warn_moderatorId_users_id_fk")
+  user      User  @relation("warn_userIdTousers", fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "warn_userId_users_id_fk")
+
+  @@index([userId], map: "warn_userId_index")
+  @@map("warn")
+}
+
+model Mute {
+  id           Int       @id(map: "core_mute_pkey") @default(autoincrement())
+  createdAt    DateTime  @default(now()) @db.Timestamp(6)
+  editedAt     DateTime? @db.Timestamp(6)
+  deletedAt    DateTime? @db.Timestamp(6)
+  guildId      String
+  userId       String
+  moderatorId  String
+  reason       String
+  endsAt       DateTime  @db.Timestamp(6)
+  deleteReason String?
+
+  guild     Guild @relation(fields: [guildId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "mute_guildId_guild_id_fk")
+  moderator User  @relation("mute_moderatorIdTousers", fields: [moderatorId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "mute_moderatorId_users_id_fk")
+  user      User  @relation("mute_userIdTousers", fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "mute_userId_users_id_fk")
+
+  @@index([userId], map: "mute_userId_index")
+  @@map("mute")
+}
+
+model ChannelRestriction {
+  id           Int       @id @default(autoincrement())
+  createdAt    DateTime  @default(now()) @db.Timestamp(6)
+  deletedAt    DateTime? @db.Timestamp(6)
+  guildId      String
+  channelId    String
+  userId       String
+  moderatorId  String
+  reason       String
+  endsAt       DateTime? @db.Timestamp(6)
+  deleteReason String?
+
+  guild     Guild @relation(fields: [guildId], references: [id])
+  moderator User  @relation("moderator", fields: [moderatorId], references: [id])
+  user      User  @relation("user", fields: [userId], references: [id])
+}
+
+model Ultimatum {
+  id        Int       @id @default(autoincrement())
+  createdAt DateTime  @default(now())
+  expiresAt DateTime
+  endedAt   DateTime?
+  userId    String
+  guildId   String
+  reason    String
+
+  guild Guild @relation(fields: [guildId], references: [id])
+  user  User  @relation(fields: [userId], references: [id])
+}

--- a/packages/db/prisma/models/profile.prisma
+++ b/packages/db/prisma/models/profile.prisma
@@ -1,3 +1,4 @@
+// TODO)) Should be per-guild
 model ProfileSettings {
   userId          String        @id @unique
   titleId         Int?

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -134,61 +134,6 @@ model ProtectedInvite {
   guild   Guild  @relation(fields: [guildId], references: [id])
 }
 
-model InventoryItem {
-  id        Int       @id(map: "core_inventory_item_pkey") @default(autoincrement())
-  itemId    Int
-  userId    String
-  createdAt DateTime  @default(now()) @db.Timestamp(6)
-  deletedAt DateTime? @db.Timestamp(6)
-
-  item Item @relation(fields: [itemId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "inventoryItem_itemId_item_id_fk")
-  user User @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "inventoryItem_userId_users_id_fk")
-
-  @@map("inventoryItem")
-}
-
-// TODO)) `canBeTraded` or something like that to limit trading of items.
-// For the time being, only type=`item` items are tradeable.
-// TODO)) Some items (like type=`profileTitle`) should be unique per user.
-// TODO)) Items should be guild-specific, along with all their relations!!!
-model Item {
-  id          Int       @id(map: "core_item_pkey") @default(autoincrement())
-  description String?
-  createdAt   DateTime  @default(now()) @db.Timestamp(6)
-  editedAt    DateTime? @db.Timestamp(6)
-  deletedAt   DateTime? @db.Timestamp(6)
-  createdBy   String
-  type        ItemType  @default(item)
-  name        String
-
-  inventoryItem   InventoryItem[]
-  creator         User              @relation(fields: [createdBy], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "item_createdBy_users_id_fk")
-  shopItem        ShopItem[]
-  profileSettings ProfileSettings[]
-  badge           Badge?
-  tintColor       TintColor?
-
-  @@map("item")
-}
-
-model Badge {
-  id     Int   @id() @default(autoincrement())
-  itemId Int   @unique
-  image  Bytes // PNG binary data, 128x128px
-
-  item                Item                    @relation(fields: [itemId], references: [id])
-  displayedInProfiles DisplayedProfileBadge[]
-}
-
-model TintColor {
-  id     Int @id @default(autoincrement())
-  itemId Int @unique
-  color  Int
-
-  item           Item              @relation(fields: [itemId], references: [id])
-  usedInProfiles ProfileSettings[]
-}
-
 model Mute {
   id           Int       @id(map: "core_mute_pkey") @default(autoincrement())
   createdAt    DateTime  @default(now()) @db.Timestamp(6)
@@ -206,20 +151,6 @@ model Mute {
 
   @@index([userId], map: "mute_userId_index")
   @@map("mute")
-}
-
-model ShopItem {
-  id        Int       @id(map: "core_shop_item_pkey") @default(autoincrement())
-  itemId    Int
-  price     Int
-  createdAt DateTime  @default(now()) @db.Timestamp(6)
-  editedAt  DateTime? @db.Timestamp(6)
-  deletedAt DateTime? @db.Timestamp(6)
-  createdBy String
-  creator   User      @relation(fields: [createdBy], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "shopItem_createdBy_users_id_fk")
-  item      Item      @relation(fields: [itemId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "shopItem_itemId_item_id_fk")
-
-  @@map("shopItem")
 }
 
 model Transaction {
@@ -378,13 +309,4 @@ enum DiscordButtonStyle {
   premium
 
   @@map("button_style")
-}
-
-enum ItemType {
-  item
-  profileTitle
-  badge // Specifies `badge`
-  staticTintColor // Specifies `tintColor`
-  dynamicTintColorAccess
-  customTintColorAccess
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -99,6 +99,7 @@ model Guild {
   voiceSessions       VoiceSession[]
   lastFishings        LastFishing[]
   giveaways           Giveaway[]
+  items               Item[]
 
   @@map("guild")
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -32,22 +32,6 @@ model ColorRole {
   @@map("colorRole")
 }
 
-model Currency {
-  id                               Int      @id(map: "core_currency_pkey") @default(autoincrement())
-  name                             String
-  symbol                           String
-  guildId                          String
-  createdBy                        String
-  createdAt                        DateTime @default(now()) @db.Timestamp(6)
-  user                             User     @relation(fields: [createdBy], references: [id], onDelete: SetNull, onUpdate: NoAction, map: "currency_createdBy_users_id_fk")
-  guild                            Guild    @relation(fields: [guildId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "currency_guildId_guild_id_fk")
-  wallet_wallet_currencyTocurrency Wallet[] @relation("wallet_currencyTocurrency")
-
-  @@unique([guildId, name], map: "currency_guildId_name_unique")
-  @@unique([guildId, symbol], map: "currency_guildId_symbol_unique")
-  @@map("currency")
-}
-
 model DailyPointsRedeems {
   id        Int      @id(map: "strata_daily_points_redeems_pkey") @default(autoincrement())
   guildId   String
@@ -135,42 +119,6 @@ model ProtectedInvite {
   guild   Guild  @relation(fields: [guildId], references: [id])
 }
 
-model Mute {
-  id           Int       @id(map: "core_mute_pkey") @default(autoincrement())
-  createdAt    DateTime  @default(now()) @db.Timestamp(6)
-  editedAt     DateTime? @db.Timestamp(6)
-  deletedAt    DateTime? @db.Timestamp(6)
-  guildId      String
-  userId       String
-  moderatorId  String
-  reason       String
-  endsAt       DateTime  @db.Timestamp(6)
-  deleteReason String?
-  guild        Guild     @relation(fields: [guildId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "mute_guildId_guild_id_fk")
-  moderator    User      @relation("mute_moderatorIdTousers", fields: [moderatorId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "mute_moderatorId_users_id_fk")
-  user         User      @relation("mute_userIdTousers", fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "mute_userId_users_id_fk")
-
-  @@index([userId], map: "mute_userId_index")
-  @@map("mute")
-}
-
-model Transaction {
-  id              Int             @id(map: "core_transaction_pkey") @default(autoincrement())
-  walletId        Int             @map("wallet")
-  relatedWalletId Int?            @map("relatedWallet")
-  relatedUserId   String?
-  amount          Int
-  createdAt       DateTime        @default(now()) @db.Timestamp(6)
-  reason          String?
-  transactionType TransactionType
-  entryType       EntryType
-  relatedUser     User?           @relation(fields: [relatedUserId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "transaction_relatedUserId_users_id_fk")
-  relatedWallet   Wallet?         @relation("transaction_relatedWalletTowallet", fields: [relatedWalletId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "transaction_relatedWallet_wallet_id_fk")
-  wallet          Wallet          @relation("transaction_walletTowallet", fields: [walletId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "transaction_wallet_wallet_id_fk")
-
-  @@map("transaction")
-}
-
 model User {
   id                                String                             @id(map: "core_users_pkey")
   verificationLevel                 VerificationLevel?
@@ -212,55 +160,6 @@ model User {
   @@map("users")
 }
 
-model Wallet {
-  id                  Int           @id(map: "core_wallet_pkey") @default(autoincrement())
-  name                String
-  userId              String
-  currencyId          Int           @map("currency")
-  default             Boolean       @default(false)
-  createdAt           DateTime      @default(now()) @db.Timestamp(6)
-  guildId             String
-  balance             Int           @default(0)
-  relatedTransactions Transaction[] @relation("transaction_relatedWalletTowallet")
-  transactions        Transaction[] @relation("transaction_walletTowallet")
-  currency            Currency      @relation("wallet_currencyTocurrency", fields: [currencyId], references: [id], onDelete: Cascade, onUpdate: NoAction, map: "wallet_currency_currency_id_fk")
-  guild               Guild         @relation(fields: [guildId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "wallet_guildId_guild_id_fk")
-  user                User          @relation(fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "wallet_userId_users_id_fk")
-
-  @@unique([userId, name, guildId], map: "wallet_userId_name_guildId_unique")
-  @@map("wallet")
-}
-
-model Warn {
-  id           Int       @id(map: "core_warn_pkey") @default(autoincrement())
-  createdAt    DateTime  @default(now()) @db.Timestamp(6)
-  editedAt     DateTime? @db.Timestamp(6)
-  guildId      String
-  userId       String
-  moderatorId  String
-  reason       String
-  deletedAt    DateTime? @db.Timestamp(6)
-  deleteReason String?
-  guild        Guild     @relation(fields: [guildId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "warn_guildId_guild_id_fk")
-  moderator    User      @relation("warn_moderatorIdTousers", fields: [moderatorId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "warn_moderatorId_users_id_fk")
-  user         User      @relation("warn_userIdTousers", fields: [userId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "warn_userId_users_id_fk")
-
-  @@index([userId], map: "warn_userId_index")
-  @@map("warn")
-}
-
-model Ultimatum {
-  id        Int       @id @default(autoincrement())
-  createdAt DateTime  @default(now())
-  expiresAt DateTime
-  endedAt   DateTime?
-  userId    String
-  guildId   String
-  reason    String
-  guild     Guild     @relation(fields: [guildId], references: [id])
-  user      User      @relation(fields: [userId], references: [id])
-}
-
 model StickyMessage {
   id            Int     @id @default(autoincrement())
   guildId       String
@@ -269,36 +168,6 @@ model StickyMessage {
   content       Json
   enabled       Boolean
   guild         Guild   @relation(fields: [guildId], references: [id])
-}
-
-model ChannelRestriction {
-  id           Int       @id @default(autoincrement())
-  createdAt    DateTime  @default(now()) @db.Timestamp(6)
-  deletedAt    DateTime? @db.Timestamp(6)
-  guildId      String
-  channelId    String
-  userId       String
-  moderatorId  String
-  reason       String
-  endsAt       DateTime? @db.Timestamp(6)
-  deleteReason String?
-  guild        Guild     @relation(fields: [guildId], references: [id])
-  moderator    User      @relation("moderator", fields: [moderatorId], references: [id])
-  user         User      @relation("user", fields: [userId], references: [id])
-}
-
-enum EntryType {
-  debit
-  credit
-
-  @@map("entry_type")
-}
-
-enum TransactionType {
-  transfer
-  add
-
-  @@map("transaction_type")
 }
 
 enum DiscordButtonStyle {


### PR DESCRIPTION
- Add a `guildId` field to the Item model to make all items guild-scoped
- Assign `211261411119202305` as `guildId` to all existing items
- Add filters in all item-related modules (items, inventory, shop, profile)
- Some splitting of the prisma schema