### PR TITLE
banner formatting fixes

### DIFF
--- a/apps/bot/src/giveaway/giveaway.ts
+++ b/apps/bot/src/giveaway/giveaway.ts
@@ -93,7 +93,7 @@ export const giveaway = new Hashira({ name: "giveaway" })
               : GiveawayBannerRatio.Auto;
 
           const files: AttachmentBuilder[] = [];
-          let ext: string | undefined;
+          let imageURL: string;
 
           if (banner && ratio !== GiveawayBannerRatio.None) {
             if (banner.size > 4_000_000) {
@@ -103,8 +103,7 @@ export const giveaway = new Hashira({ name: "giveaway" })
               );
             }
 
-            const [buffer, returnedExt] = await formatBanner(banner, ratio);
-            ext = returnedExt;
+            const [buffer, ext] = await formatBanner(banner, ratio);
             if (!buffer) {
               return await errorFollowUp(
                 itx,
@@ -114,6 +113,9 @@ export const giveaway = new Hashira({ name: "giveaway" })
 
             const attachment = new AttachmentBuilder(buffer).setName(`banner.${ext}`);
             files.push(attachment);
+            imageURL = `attachment://banner.${ext}`;
+          } else {
+            imageURL = getStaticBanner(title || "Giveaway");
           }
 
           const parsedRewards: GiveawayReward[] = parseRewards(rewards);
@@ -142,11 +144,7 @@ export const giveaway = new Hashira({ name: "giveaway" })
               mg.addItems((mgi) =>
                 mgi
                   .setDescription(`Banner for giveaway: ${title || "Giveaway"}`)
-                  .setURL(
-                    banner
-                      ? `attachment://banner.${ext}`
-                      : getStaticBanner(title || "Giveaway"),
-                  ),
+                  .setURL(imageURL),
               ),
             );
           }

--- a/apps/bot/src/giveaway/giveaway.ts
+++ b/apps/bot/src/giveaway/giveaway.ts
@@ -20,7 +20,6 @@ import { waitForButtonClick } from "../util/singleUseButton";
 import {
   GiveawayBannerRatio,
   formatBanner,
-  getExtension,
   getStaticBanner,
   giveawayButtonRow,
   leaveButtonRow,
@@ -65,8 +64,8 @@ export const giveaway = new Hashira({ name: "giveaway" })
           .addChoices(
             { name: "Brak baneru", value: GiveawayBannerRatio.None },
             { name: "Bez zmian", value: GiveawayBannerRatio.Auto },
-            { name: "Szeroki", value: GiveawayBannerRatio.Landscape },
-            { name: "Wysoki", value: GiveawayBannerRatio.Portrait },
+            { name: "Szeroki (3:1)", value: GiveawayBannerRatio.Landscape },
+            { name: "Wysoki (2:3)", value: GiveawayBannerRatio.Portrait },
           ),
       )
       .handle(
@@ -94,6 +93,8 @@ export const giveaway = new Hashira({ name: "giveaway" })
               : GiveawayBannerRatio.Auto;
 
           const files: AttachmentBuilder[] = [];
+          let ext: string | undefined;
+
           if (banner && ratio !== GiveawayBannerRatio.None) {
             if (banner.size > 4_000_000) {
               return await errorFollowUp(
@@ -101,7 +102,9 @@ export const giveaway = new Hashira({ name: "giveaway" })
                 `Baner jest za duży (>4MB). Aktualny rozmiar pliku: ${round(banner.size / 1_000_000, 1)} MB.`,
               );
             }
-            const [buffer, ext] = await formatBanner(banner, ratio);
+
+            const [buffer, returnedExt] = await formatBanner(banner, ratio);
+            ext = returnedExt;
             if (!buffer) {
               return await errorFollowUp(
                 itx,
@@ -141,7 +144,7 @@ export const giveaway = new Hashira({ name: "giveaway" })
                   .setDescription(`Banner for giveaway: ${title || "Giveaway"}`)
                   .setURL(
                     banner
-                      ? `attachment://banner.${getExtension(banner.contentType)}`
+                      ? `attachment://banner.${ext}`
                       : getStaticBanner(title || "Giveaway"),
                   ),
               ),

--- a/apps/bot/src/giveaway/util.ts
+++ b/apps/bot/src/giveaway/util.ts
@@ -133,7 +133,7 @@ export async function formatBanner(
 
   // Gets animation loop count from metadata, defaults to 0 (infinite)
   const metadata = await sharp(buffer, { animated: true }).metadata();
-  const loop = typeof metadata.loop === "number" ? metadata.loop : 0;
+  const loop = metadata.loop ?? 0;
 
   const formatted = await sharp(buffer, { animated: true })
     .resize(targetWidth, targetHeight, {

--- a/apps/bot/src/giveaway/util.ts
+++ b/apps/bot/src/giveaway/util.ts
@@ -25,7 +25,7 @@ import sharp from "sharp";
 enum GiveawayBannerRatio {
   None = 0, // No Banner
   Auto = 1,
-  Landscape = 2, // 4:1
+  Landscape = 2, // 3:1
   Portrait = 3, // 2:3
 }
 
@@ -69,14 +69,7 @@ export function parseRewards(input: string): GiveawayReward[] {
     });
 }
 
-const allowedMimeTypes = [
-  "image/png",
-  "image/jpeg",
-  "image/apng",
-  "image/webp",
-  "image/gif",
-  "image/avif",
-];
+const allowedMimeTypes = ["image/png", "image/jpeg", "image/webp", "image/gif"];
 
 export function getExtension(mimeType: string | null) {
   if (!mimeType) return "webp";
@@ -112,7 +105,7 @@ export async function formatBanner(
   const targetAspect = (() => {
     switch (ratio) {
       case GiveawayBannerRatio.Landscape:
-        return 4 / 1;
+        return 3 / 1;
 
       case GiveawayBannerRatio.Portrait:
         return 2 / 3;
@@ -138,12 +131,16 @@ export async function formatBanner(
     targetHeight = Math.round(maxSide / targetAspect);
   }
 
+  // Gets animation loop count from metadata, defaults to 0 (infinite)
+  const metadata = await sharp(buffer, { animated: true }).metadata();
+  const loop = typeof metadata.loop === "number" ? metadata.loop : 0;
+
   const formatted = await sharp(buffer, { animated: true })
     .resize(targetWidth, targetHeight, {
       fit: "cover",
       position: "centre",
     })
-    .toFormat("webp")
+    .toFormat("webp", { loop })
     .toBuffer();
 
   return [formatted, "webp"];


### PR DESCRIPTION
Changes:
- now using correct extension returned by formatBanner, not getExtension
- landscape is now 3:1 instead of 4:1, since it was too wide
- removed broken mimetypes
- animation loop count from metadata
- added exact aspect ratio numeric labels to command choices