### PR TITLE
feat(giveaway): more giveaway related actions

### DIFF
--- a/apps/bot/src/giveaway/giveaway.ts
+++ b/apps/bot/src/giveaway/giveaway.ts
@@ -227,6 +227,7 @@ export const giveaway = new Hashira({ name: "giveaway" })
 
               const giveaway = await prisma.giveaway.create({
                 data: {
+                  authorId: itx.user.id,
                   messageId: response.id,
                   channelId: response.channelId,
                   guildId: response.guildId,

--- a/apps/bot/src/giveaway/giveaway.ts
+++ b/apps/bot/src/giveaway/giveaway.ts
@@ -1,7 +1,8 @@
 import { Hashira } from "@hashira/core";
 import type { GiveawayParticipant, GiveawayReward } from "@hashira/db";
-import { type Duration, addSeconds } from "date-fns";
+import { type Duration, addSeconds, formatDuration } from "date-fns";
 import {
+  type APIContainerComponent,
   AttachmentBuilder,
   ButtonBuilder,
   ButtonStyle,
@@ -9,6 +10,7 @@ import {
   ContainerBuilder,
   MessageFlags,
   SeparatorSpacingSize,
+  TextDisplayBuilder,
   time,
 } from "discord.js";
 import { round } from "es-toolkit";
@@ -29,211 +31,322 @@ import {
 
 export const giveaway = new Hashira({ name: "giveaway" })
   .use(base)
-  .command("givek", (command) =>
-    command
+  .group("givek", (group) =>
+    group
+      .setDescription("Komendy do givków.")
       .setDMPermission(false)
-      .setDescription("Tworzenie giveawayów z różnymi nagrodami")
-      .addString("nagrody", (rewards) =>
-        rewards.setDescription(
-          "Nagrody do rozdania, oddzielone przecinkami, gdy nagród jest więcej to piszemy np. 2x200 punktów",
-        ),
-      )
-      .addString("czas-trwania", (duration) =>
-        duration.setDescription(
-          "Czas trwania givka, np. 1d (1 dzień) lub 2h (2 godziny)",
-        ),
-      )
-      .addString("tytul", (tytul) =>
-        tytul
-          .setDescription("Tytuł giveaway'a, domyślnie 'Giveaway'")
-          .setRequired(false),
-      )
-      .addAttachment("baner", (baner) =>
-        baner
-          .setDescription(
-            "Baner wyświetlany na górze giveaway'a. Domyślny można wyłączyć ustawiając format na brak.",
+      .addCommand("stworz", (command) =>
+        command
+          .setDescription("Tworzenie giveawayów z różnymi nagrodami")
+          .addString("nagrody", (rewards) =>
+            rewards.setDescription(
+              "Nagrody do rozdania, oddzielone przecinkami, gdy nagród jest więcej to piszemy np. 2x200 punktów",
+            ),
           )
-          .setRequired(false),
-      )
-      .addNumber("format-baneru", (format) =>
-        format
-          .setDescription(
-            "Konwertuje baner do wybranego współczynnika proporcji, domyślnie 'Bez zmian'.",
+          .addString("czas-trwania", (duration) =>
+            duration.setDescription(
+              "Czas trwania givka, np. 1d (1 dzień) lub 2h (2 godziny)",
+            ),
           )
-          .setRequired(false)
-          .addChoices(
-            { name: "Brak baneru", value: GiveawayBannerRatio.None },
-            { name: "Bez zmian", value: GiveawayBannerRatio.Auto },
-            { name: "Szeroki (3:1)", value: GiveawayBannerRatio.Landscape },
-            { name: "Wysoki (2:3)", value: GiveawayBannerRatio.Portrait },
+          .addString("tytul", (tytul) =>
+            tytul
+              .setDescription("Tytuł giveaway'a, domyślnie 'Giveaway'")
+              .setRequired(false),
+          )
+          .addAttachment("baner", (baner) =>
+            baner
+              .setDescription(
+                "Baner wyświetlany na górze giveaway'a. Domyślny można wyłączyć ustawiając format na brak.",
+              )
+              .setRequired(false),
+          )
+          .addNumber("format-baneru", (format) =>
+            format
+              .setDescription(
+                "Konwertuje baner do wybranego współczynnika proporcji, domyślnie 'Bez zmian'.",
+              )
+              .setRequired(false)
+              .addChoices(
+                { name: "Brak baneru", value: GiveawayBannerRatio.None },
+                { name: "Bez zmian", value: GiveawayBannerRatio.Auto },
+                { name: "Szeroki (3:1)", value: GiveawayBannerRatio.Landscape },
+                { name: "Wysoki (2:3)", value: GiveawayBannerRatio.Portrait },
+              ),
+          )
+          .handle(
+            async (
+              { prisma, messageQueue },
+              {
+                nagrody: rewards,
+                "czas-trwania": duration,
+                tytul: title,
+                baner: banner,
+                "format-baneru": format,
+              },
+              itx,
+            ) => {
+              if (!itx.inCachedGuild()) return;
+              await ensureUserExists(prisma, itx.user);
+
+              await itx.deferReply({
+                flags: MessageFlags.Ephemeral,
+              });
+
+              const ratio: GiveawayBannerRatio =
+                format !== null
+                  ? (format as GiveawayBannerRatio)
+                  : GiveawayBannerRatio.Auto;
+
+              const files: AttachmentBuilder[] = [];
+              let imageURL: string;
+
+              if (banner && ratio !== GiveawayBannerRatio.None) {
+                if (banner.size > 4_000_000) {
+                  return await errorFollowUp(
+                    itx,
+                    `Baner jest za duży (>4MB). Aktualny rozmiar pliku: ${round(banner.size / 1_000_000, 1)} MB.`,
+                  );
+                }
+
+                const [buffer, ext] = await formatBanner(banner, ratio);
+                if (!buffer) {
+                  return await errorFollowUp(
+                    itx,
+                    `Podano nieprawidłowy format baneru. (${banner.contentType})`,
+                  );
+                }
+
+                const attachment = new AttachmentBuilder(buffer).setName(
+                  `banner.${ext}`,
+                );
+                files.push(attachment);
+                imageURL = `attachment://banner.${ext}`;
+              } else {
+                imageURL = getStaticBanner(title || "Giveaway");
+              }
+
+              const parsedRewards: GiveawayReward[] = parseRewards(rewards);
+
+              const parsedTime: Duration | null = parseDuration(duration);
+
+              if (parsedTime === null) {
+                return await errorFollowUp(itx, "Podano nieprawidłowy czas");
+              }
+
+              const durationSeconds = durationToSeconds(parsedTime);
+
+              const endTime = addSeconds(itx.createdAt, durationSeconds);
+
+              const totalRewards = parsedRewards.reduce((sum, r) => sum + r.amount, 0);
+
+              const confirmButton = new ButtonBuilder()
+                .setCustomId("confirm")
+                .setLabel("Potwierdź poprawność")
+                .setStyle(ButtonStyle.Secondary);
+
+              const messageContainer = new ContainerBuilder();
+
+              if (ratio !== GiveawayBannerRatio.None) {
+                messageContainer.addMediaGalleryComponents((mg) =>
+                  mg.addItems((mgi) =>
+                    mgi
+                      .setDescription(`Banner for giveaway: ${title || "Giveaway"}`)
+                      .setURL(imageURL),
+                  ),
+                );
+              }
+
+              messageContainer
+                .setAccentColor(0x0099ff)
+                .addTextDisplayComponents((td) =>
+                  td.setContent(`# ${title || "Giveaway"}`),
+                )
+                .addTextDisplayComponents((td) => td.setContent(`-# Host: ${itx.user}`))
+                .addSeparatorComponents((s) => s.setSpacing(SeparatorSpacingSize.Large))
+                .addTextDisplayComponents((td) =>
+                  td.setContent(
+                    `${parsedRewards.map((r) => `${r.amount}x ${r.reward}`).join("\n")}\n`,
+                  ),
+                )
+                .addTextDisplayComponents((td) =>
+                  td.setContent(`Koniec ${time(endTime, "R")}`).setId(4),
+                )
+                .addSeparatorComponents((s) => s)
+                .addTextDisplayComponents((td) =>
+                  td
+                    .setContent(`-# Uczestnicy: 0 | Łącznie nagród: ${totalRewards}`)
+                    .setId(1),
+                )
+                .addTextDisplayComponents((td) => td.setContent("-# Id: ?").setId(3))
+                .addTextDisplayComponents((td) =>
+                  td
+                    .setContent("Potwierdź jeśli wszystko się zgadza w giveawayu.")
+                    .setId(99),
+                )
+                .addActionRowComponents((ar) => ar.addComponents([confirmButton]));
+
+              const responseConfirm = await itx.editReply({
+                components: [messageContainer],
+                files: files,
+                flags: [MessageFlags.IsComponentsV2],
+              });
+
+              // Removes confirmation components
+              const confirmIndex = messageContainer.components.findIndex(
+                (c) => c.data?.id === 99 && c.data?.type === ComponentType.TextDisplay,
+              );
+              messageContainer.spliceComponents(confirmIndex, 2);
+
+              if (!responseConfirm) {
+                throw new Error("Failed to receive response from interaction reply");
+              }
+
+              const confirmation = await waitForButtonClick(
+                responseConfirm,
+                "confirm",
+                { minutes: 1 },
+                (interaction) => interaction.user.id === itx.user.id,
+              );
+
+              if (!confirmation.interaction) return;
+
+              itx.deleteReply();
+
+              messageContainer.addActionRowComponents(giveawayButtonRow.setId(2));
+
+              const response = await itx.followUp({
+                components: [messageContainer],
+                files: files,
+                withResponse: true,
+                flags: MessageFlags.IsComponentsV2,
+              });
+
+              if (!response) {
+                throw new Error("Failed to receive response from interaction reply");
+              }
+
+              const giveaway = await prisma.giveaway.create({
+                data: {
+                  messageId: response.id,
+                  channelId: response.channelId,
+                  guildId: response.guildId,
+                  endAt: endTime,
+                  participants: { create: [] },
+                  rewards: {
+                    create: parsedRewards.map(({ amount, reward }) => ({
+                      amount,
+                      reward,
+                    })),
+                  },
+                  totalRewards: totalRewards,
+                },
+              });
+
+              await messageQueue.push(
+                "giveawayEnd",
+                { giveawayId: giveaway.id },
+                Math.floor((endTime.valueOf() - response.createdAt.valueOf()) / 1000),
+                giveaway.id.toString(),
+              );
+
+              const giveawayIdIndex = messageContainer.components.findIndex(
+                (c) => c.data?.id === 3 && c.data?.type === ComponentType.TextDisplay,
+              );
+
+              messageContainer.components[giveawayIdIndex] =
+                new TextDisplayBuilder().setContent(`-# Id: ${giveaway.id}`);
+
+              await response.edit({
+                components: [messageContainer],
+                flags: MessageFlags.IsComponentsV2,
+              });
+            },
           ),
       )
-      .handle(
-        async (
-          { prisma, messageQueue },
-          {
-            nagrody: rewards,
-            "czas-trwania": duration,
-            tytul: title,
-            baner: banner,
-            "format-baneru": format,
-          },
-          itx,
-        ) => {
-          if (!itx.inCachedGuild()) return;
-          await ensureUserExists(prisma, itx.user);
-
-          await itx.deferReply({
-            flags: MessageFlags.Ephemeral,
-          });
-
-          const ratio: GiveawayBannerRatio =
-            format !== null
-              ? (format as GiveawayBannerRatio)
-              : GiveawayBannerRatio.Auto;
-
-          const files: AttachmentBuilder[] = [];
-          let imageURL: string;
-
-          if (banner && ratio !== GiveawayBannerRatio.None) {
-            if (banner.size > 4_000_000) {
-              return await errorFollowUp(
-                itx,
-                `Baner jest za duży (>4MB). Aktualny rozmiar pliku: ${round(banner.size / 1_000_000, 1)} MB.`,
-              );
-            }
-
-            const [buffer, ext] = await formatBanner(banner, ratio);
-            if (!buffer) {
-              return await errorFollowUp(
-                itx,
-                `Podano nieprawidłowy format baneru. (${banner.contentType})`,
-              );
-            }
-
-            const attachment = new AttachmentBuilder(buffer).setName(`banner.${ext}`);
-            files.push(attachment);
-            imageURL = `attachment://banner.${ext}`;
-          } else {
-            imageURL = getStaticBanner(title || "Giveaway");
-          }
-
-          const parsedRewards: GiveawayReward[] = parseRewards(rewards);
-
-          const parsedTime: Duration | null = parseDuration(duration);
-
-          if (parsedTime === null) {
-            return await errorFollowUp(itx, "Podano nieprawidłowy czas");
-          }
-
-          const durationSeconds = durationToSeconds(parsedTime);
-
-          const endTime = addSeconds(itx.createdAt, durationSeconds);
-
-          const totalRewards = parsedRewards.reduce((sum, r) => sum + r.amount, 0);
-
-          const confirmButton = new ButtonBuilder()
-            .setCustomId("confirm")
-            .setLabel("Potwierdź poprawność")
-            .setStyle(ButtonStyle.Secondary);
-
-          const messageContainer = new ContainerBuilder();
-
-          if (ratio !== GiveawayBannerRatio.None) {
-            messageContainer.addMediaGalleryComponents((mg) =>
-              mg.addItems((mgi) =>
-                mgi
-                  .setDescription(`Banner for giveaway: ${title || "Giveaway"}`)
-                  .setURL(imageURL),
-              ),
-            );
-          }
-
-          messageContainer
-            .setAccentColor(0x0099ff)
-            .addTextDisplayComponents((td) => td.setContent(`# ${title || "Giveaway"}`))
-            .addTextDisplayComponents((td) => td.setContent(`-# Host: ${itx.user}`))
-            .addSeparatorComponents((s) => s.setSpacing(SeparatorSpacingSize.Large))
-            .addTextDisplayComponents((td) =>
-              td.setContent(
-                `${parsedRewards.map((r) => `${r.amount}x ${r.reward}`).join("\n")}
-            \nKoniec ${time(endTime, "R")}`,
-              ),
-            )
-            .addSeparatorComponents((s) => s)
-            .addTextDisplayComponents((td) =>
-              td
-                .setContent(`-# Uczestnicy: 0 | Łącznie nagród: ${totalRewards}`)
-                .setId(1),
-            )
-            .addTextDisplayComponents((td) =>
-              td
-                .setContent("Potwierdź jeśli wszystko się zgadza w giveawayu.")
-                .setId(99),
-            )
-            .addActionRowComponents((ar) => ar.addComponents([confirmButton]));
-
-          const responseConfirm = await itx.editReply({
-            components: [messageContainer],
-            files: files,
-            flags: [MessageFlags.IsComponentsV2],
-          });
-
-          // Removes confirmation components
-          const confirmIndex = messageContainer.components.findIndex(
-            (c) => c.data?.id === 99 && c.data?.type === ComponentType.TextDisplay,
-          );
-          messageContainer.spliceComponents(confirmIndex, 2);
-
-          if (!responseConfirm) {
-            throw new Error("Failed to receive response from interaction reply");
-          }
-
-          const confirmation = await waitForButtonClick(
-            responseConfirm,
-            "confirm",
-            { minutes: 1 },
-            (interaction) => interaction.user.id === itx.user.id,
-          );
-
-          if (!confirmation.interaction) return;
-
-          itx.deleteReply();
-
-          messageContainer.addActionRowComponents(giveawayButtonRow.setId(2));
-
-          const response = await itx.followUp({
-            components: [messageContainer],
-            files: files,
-            withResponse: true,
-            flags: MessageFlags.IsComponentsV2,
-          });
-
-          if (!response) {
-            throw new Error("Failed to receive response from interaction reply");
-          }
-
-          const giveaway = await prisma.giveaway.create({
-            data: {
-              messageId: response.id,
-              channelId: response.channelId,
-              guildId: response.guildId,
-              endAt: endTime,
-              participants: { create: [] },
-              rewards: {
-                create: parsedRewards.map(({ amount, reward }) => ({ amount, reward })),
+      .addCommand("dodaj-czas", (command) =>
+        command
+          .setDescription("Dodawanie czasu do istniejącego giveaway'a.")
+          .addInteger("id", (id) =>
+            id.setDescription("Id giveaway'a.").setRequired(true),
+          )
+          .addString("czas", (czas) =>
+            czas.setDescription("Czas do dodania (np. 1d, 2h, 5m).").setRequired(true),
+          )
+          .handle(async ({ prisma, messageQueue }, { id, czas }, itx) => {
+            const giveaway = await prisma.giveaway.findFirst({
+              where: {
+                id: id,
               },
-              totalRewards: totalRewards,
-            },
-          });
+            });
 
-          await messageQueue.push(
-            "giveawayEnd",
-            { giveawayId: giveaway.id },
-            Math.floor((endTime.valueOf() - response.createdAt.valueOf()) / 1000),
-            giveaway.id.toString(),
-          );
-        },
+            if (!giveaway || giveaway.endAt < itx.createdAt)
+              return await errorFollowUp(
+                itx,
+                "Ten giveaway nie istnieje lub się zakończył!",
+              );
+
+            if (itx.user.id !== giveaway.authorId)
+              return await errorFollowUp(
+                itx,
+                "Nie masz uprawnień do edycji tego giveaway'a!",
+              );
+
+            const channel = await itx.client.channels.cache.get(giveaway.channelId);
+            if (!channel || !channel.isSendable()) {
+              throw new Error(`Channel ${channel} is not sendable or not found.`);
+            }
+
+            const message = await channel.messages.fetch(giveaway.messageId);
+            if (!message || !message.components[0]) {
+              throw new Error(`Message ${message} or it's component not found.`);
+            }
+
+            const parsedTime: Duration | null = parseDuration(czas);
+
+            if (parsedTime === null) {
+              return await errorFollowUp(itx, "Podano nieprawidłowy czas");
+            }
+
+            const durationSeconds = durationToSeconds(parsedTime);
+
+            const newEndTime = addSeconds(giveaway.endAt, durationSeconds);
+
+            const container = new ContainerBuilder(
+              message.components[0].toJSON() as APIContainerComponent,
+            );
+
+            const timeIndex = container.components.findIndex(
+              (c) => c.data?.id === 4 && c.data?.type === ComponentType.TextDisplay,
+            );
+
+            if (timeIndex === -1) return;
+
+            container.components[timeIndex] = new TextDisplayBuilder().setContent(
+              `Koniec ${time(newEndTime, "R")}`,
+            );
+
+            await message.edit({ components: [container] });
+
+            await messageQueue.updateDelay(
+              "giveawayEnd",
+              giveaway.id.toString(),
+              newEndTime,
+            );
+
+            await prisma.giveaway.update({
+              where: {
+                id: id,
+              },
+              data: {
+                endAt: newEndTime,
+              },
+            });
+
+            await itx.reply({
+              content: `Pomyślnie dodano do czasu ${formatDuration(parsedTime)}, giveaway zakończy się ${time(newEndTime, "R")}.\n-# Id: ${giveaway.id}`,
+              flags: "Ephemeral",
+            });
+          }),
       ),
   )
   .handle("ready", async ({ prisma }, client) => {

--- a/apps/bot/src/giveaway/util.ts
+++ b/apps/bot/src/giveaway/util.ts
@@ -18,6 +18,7 @@ import {
   MessageFlags,
   SeparatorSpacingSize,
   TextDisplayBuilder,
+  messageLink,
 } from "discord.js";
 import { shuffle } from "es-toolkit";
 import sharp from "sharp";
@@ -144,6 +145,10 @@ export async function formatBanner(
     .toBuffer();
 
   return [formatted, "webp"];
+}
+
+export function giveawayFooter(giveaway: Giveaway) {
+  return `\n-# Id: ${giveaway.id} ${messageLink(giveaway.channelId, giveaway.messageId, giveaway.guildId)}`;
 }
 
 export function getStaticBanner(title: string) {

--- a/apps/bot/src/giveaway/util.ts
+++ b/apps/bot/src/giveaway/util.ts
@@ -10,7 +10,6 @@ import {
   ActionRowBuilder,
   type Attachment,
   ButtonBuilder,
-  type ButtonInteraction,
   ButtonStyle,
   ComponentType,
   ContainerBuilder,
@@ -158,18 +157,18 @@ export function getStaticBanner(title: string) {
 }
 
 export async function updateGiveaway(
-  i: ButtonInteraction,
+  message: Message<boolean>,
   giveaway: Giveaway,
   prisma: ExtendedPrismaClient,
 ) {
-  if (giveaway && i.message.components[0]) {
+  if (giveaway && message.components[0]) {
     const participants: GiveawayParticipant[] =
       await prisma.giveawayParticipant.findMany({
         where: { giveawayId: giveaway.id, isRemoved: false },
       });
 
     const container = new ContainerBuilder(
-      i.message.components[0].toJSON() as APIContainerComponent,
+      message.components[0].toJSON() as APIContainerComponent,
     );
 
     const footerIndex = container.components.findIndex(
@@ -182,7 +181,7 @@ export async function updateGiveaway(
       `-# Uczestnicy: ${participants.length} | Łącznie nagród: ${giveaway.totalRewards}`,
     );
 
-    await i.message.edit({ components: [container] });
+    await message.edit({ components: [container] });
   }
 }
 

--- a/packages/db/prisma/migrations/20250818191254_add_giveaway_feat/migration.sql
+++ b/packages/db/prisma/migrations/20250818191254_add_giveaway_feat/migration.sql
@@ -1,0 +1,10 @@
+-- AlterTable
+ALTER TABLE "Giveaway" ADD COLUMN     "authorId" TEXT NOT NULL DEFAULT '1015002135571734538',
+ADD COLUMN     "roleBlacklist" TEXT[],
+ADD COLUMN     "roleWhitelist" TEXT[];
+
+-- AlterTable
+ALTER TABLE "GiveawayParticipant" ADD COLUMN     "forcefullyRemoved" BOOLEAN NOT NULL DEFAULT false;
+
+-- AddForeignKey
+ALTER TABLE "Giveaway" ADD CONSTRAINT "Giveaway_authorId_fkey" FOREIGN KEY ("authorId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/db/prisma/migrations/20250818191416_remove_giveaway_author_id_def/migration.sql
+++ b/packages/db/prisma/migrations/20250818191416_remove_giveaway_author_id_def/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Giveaway" ALTER COLUMN "authorId" DROP DEFAULT;

--- a/packages/db/prisma/models/giveaway.prisma
+++ b/packages/db/prisma/models/giveaway.prisma
@@ -2,11 +2,16 @@ model Giveaway {
   id        Int      @id @default(autoincrement())
   createdAt DateTime @default(now())
   endAt     DateTime
+  author    User     @relation(fields: [authorId], references: [id])
+  authorId  String
 
   guild     Guild  @relation(fields: [guildId], references: [id])
   guildId   String
   channelId String
   messageId String
+
+  roleWhitelist String[]
+  roleBlacklist String[]
 
   participants GiveawayParticipant[]
   winners      GiveawayWinner[]
@@ -19,9 +24,10 @@ model GiveawayParticipant {
   giveaway   Giveaway @relation(fields: [giveawayId], references: [id])
   giveawayId Int
 
-  user      User    @relation(fields: [userId], references: [id])
-  userId    String
-  isRemoved Boolean @default(false)
+  user              User    @relation(fields: [userId], references: [id])
+  userId            String
+  isRemoved         Boolean @default(false)
+  forcefullyRemoved Boolean @default(false)
 }
 
 model GiveawayWinner {

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -156,6 +156,7 @@ model User {
   receivedChannelRestrictions       ChannelRestriction[]               @relation("user")
   giveawayParticipations            GiveawayParticipant[]
   giveawayWinnings                  GiveawayWinner[]
+  giveaways                         Giveaway[]
 
   @@map("users")
 }


### PR DESCRIPTION
Added commands for:
- rerolling
- listing participants after results
- removing users from giveaway
- adding time to exisiting giveaway

Now displays giveaway id for usage in above commands. 
Upgraded duration parser to parse multiple units at once and negative durations.