### PR TITLE
feat(colorRoles): Support gradient role colors

### DIFF
--- a/apps/bot/src/strata/colorRoles.ts
+++ b/apps/bot/src/strata/colorRoles.ts
@@ -297,10 +297,12 @@ export const colorRoles = new Hashira({ name: "color-role" })
               );
 
               if (result) {
+                const colorStrings = [`#${primaryColor.toString(16)}`];
+                if (newColors.secondaryColor) {
+                  colorStrings.push(`#${newColors.secondaryColor.toString(16)}`);
+                }
                 await itx.editReply({
-                  content: `Zmieniono kolor roli ${role.name} na #${primaryColor.toString(
-                    16,
-                  )}`,
+                  content: `Zmieniono kolor roli ${role.name} na ${colorStrings.join(" -> ")}}`,
                 });
               }
             },

--- a/apps/bot/src/strata/colorRoles.ts
+++ b/apps/bot/src/strata/colorRoles.ts
@@ -4,12 +4,14 @@ import {
   type ColorResolvable,
   PermissionFlagsBits,
   RESTJSONErrorCodes,
+  type RoleColorsResolvable,
   inlineCode,
   resolveColor,
   time,
 } from "discord.js";
 import { base } from "../base";
 import { discordTry } from "../util/discordTry";
+import { ensureUserExists } from "../util/ensureUsersExist";
 import { errorFollowUp } from "../util/errorFollowUp";
 
 const preprocessColor = (color: string): `#${string}` => {
@@ -81,6 +83,9 @@ export const colorRoles = new Hashira({ name: "color-role" })
               { name: "10", value: 10 },
             ),
           )
+          .addBoolean("gradient", (gradient) =>
+            gradient.setDescription("Czy kolor roli może używać gradientów"),
+          )
           .handle(
             async (
               { prisma },
@@ -89,6 +94,7 @@ export const colorRoles = new Hashira({ name: "color-role" })
                 właściciel: owner,
                 wygaśnięcie: rawExpiration,
                 sloty: slots,
+                gradient,
               },
               itx,
             ) => {
@@ -120,6 +126,7 @@ export const colorRoles = new Hashira({ name: "color-role" })
               );
               if (!role) return;
 
+              await ensureUserExists(prisma, owner.id);
               await prisma.colorRole.create({
                 data: {
                   name,
@@ -128,6 +135,7 @@ export const colorRoles = new Hashira({ name: "color-role" })
                   expiration,
                   roleId: role.id,
                   slots,
+                  gradient,
                 },
               });
 
@@ -154,10 +162,16 @@ export const colorRoles = new Hashira({ name: "color-role" })
           .addInteger("sloty", (slots) =>
             slots.setDescription("Ilość slotów na użytkowników"),
           )
+
+          .addBoolean("gradient", (gradient) =>
+            gradient
+              .setDescription("Czy kolor roli może używać gradientów")
+              .setRequired(false),
+          )
           .handle(
             async (
               { prisma },
-              { rola: role, właściciel: owner, sloty: slots },
+              { rola: role, właściciel: owner, sloty: slots, gradient },
               itx,
             ) => {
               if (!itx.inCachedGuild()) return;
@@ -182,6 +196,7 @@ export const colorRoles = new Hashira({ name: "color-role" })
                       data: {
                         ownerId: owner.id,
                         slots,
+                        ...(gradient !== null ? { gradient } : {}),
                       },
                     });
 
@@ -196,6 +211,7 @@ export const colorRoles = new Hashira({ name: "color-role" })
                 return;
               }
 
+              await ensureUserExists(prisma, owner.id);
               await prisma.colorRole.create({
                 data: {
                   name: role.name,
@@ -219,42 +235,75 @@ export const colorRoles = new Hashira({ name: "color-role" })
           .addRole("rola", (role) =>
             role.setDescription("Rola której kolor zmienić").setRequired(true),
           )
-          .addString("kolor", (color) =>
-            color.setDescription("Hex jaki ustawić").setRequired(true),
+          .addString("kolor", (primaryColor) =>
+            primaryColor.setDescription("Hex jaki ustawić").setRequired(true),
           )
-          .handle(async ({ prisma }, { rola: role, kolor: color }, itx) => {
-            if (!itx.inCachedGuild()) return;
+          .addString("kolor2", (secondaryColor) =>
+            secondaryColor
+              .setDescription("Drugi kolor do gradientu (jeśli rola może ich używać)")
+              .setRequired(false),
+          )
+          .handle(
+            async (
+              { prisma },
+              { rola: role, kolor: rawPrimaryColor, kolor2: rawSecondaryColor },
+              itx,
+            ) => {
+              if (!itx.inCachedGuild()) return;
 
-            await itx.deferReply();
+              await itx.deferReply();
 
-            const hexColor = getColor(color);
-            if (!hexColor) return await errorFollowUp(itx, "Invalid color");
+              const primaryColor = getColor(rawPrimaryColor);
+              if (!primaryColor)
+                return await errorFollowUp(
+                  itx,
+                  `Niepoprawny kolor: ${rawPrimaryColor}`,
+                );
 
-            const colorRole = await prisma.colorRole.findFirst({
-              where: {
-                ownerId: itx.user.id,
-                guildId: itx.guildId,
-                roleId: role.id,
-              },
-            });
-
-            if (!colorRole) {
-              return await errorFollowUp(itx, "You do not own this role");
-            }
-
-            const result = await discordTry(
-              () => role.setColor(hexColor),
-              [RESTJSONErrorCodes.MissingPermissions],
-              () => errorFollowUp(itx, "Missing permissions"),
-            );
-
-            if (result) {
-              await itx.editReply({
-                content: `Zmieniono kolor roli ${role.name} na #${hexColor.toString(
-                  16,
-                )}`,
+              const colorRole = await prisma.colorRole.findFirst({
+                where: {
+                  ownerId: itx.user.id,
+                  guildId: itx.guildId,
+                  roleId: role.id,
+                },
               });
-            }
-          }),
+
+              if (!colorRole) {
+                return await errorFollowUp(itx, "Nie jesteś właścicielem tej roli");
+              }
+
+              const newColors: RoleColorsResolvable = { primaryColor };
+
+              if (rawSecondaryColor) {
+                if (!colorRole.gradient) {
+                  return await errorFollowUp(itx, "Ta rola nie może używać gradientów");
+                }
+
+                const secondaryColor = getColor(rawSecondaryColor);
+                if (!secondaryColor) {
+                  return await errorFollowUp(
+                    itx,
+                    `Niepoprawny kolor: ${rawSecondaryColor}`,
+                  );
+                }
+
+                newColors.secondaryColor = secondaryColor;
+              }
+
+              const result = await discordTry(
+                () => role.setColors(newColors),
+                [RESTJSONErrorCodes.MissingPermissions],
+                () => errorFollowUp(itx, "Missing permissions"),
+              );
+
+              if (result) {
+                await itx.editReply({
+                  content: `Zmieniono kolor roli ${role.name} na #${primaryColor.toString(
+                    16,
+                  )}`,
+                });
+              }
+            },
+          ),
       ),
   );

--- a/bun.lock
+++ b/bun.lock
@@ -5,7 +5,7 @@
       "name": "hashira",
       "dependencies": {
         "@hashira/utils": "workspace:*",
-        "discord.js": "^14.19.2",
+        "discord.js": "^14.22.1",
         "es-toolkit": "^1.36.0",
         "valibot": "^1.0.0",
       },
@@ -108,7 +108,7 @@
 
     "@discordjs/formatters": ["@discordjs/formatters@0.6.1", "", { "dependencies": { "discord-api-types": "^0.38.1" } }, "sha512-5cnX+tASiPCqCWtFcFslxBVUaCetB0thvM/JyavhbXInP1HJIEU+Qv/zMrnuwSsX3yWH2lVXNJZeDK3EiP4HHg=="],
 
-    "@discordjs/rest": ["@discordjs/rest@2.5.1", "", { "dependencies": { "@discordjs/collection": "^2.1.1", "@discordjs/util": "^1.1.1", "@sapphire/async-queue": "^1.5.3", "@sapphire/snowflake": "^3.5.3", "@vladfrangu/async_event_emitter": "^2.4.6", "discord-api-types": "^0.38.1", "magic-bytes.js": "^1.10.0", "tslib": "^2.6.3", "undici": "6.21.3" } }, "sha512-Tg9840IneBcbrAjcGaQzHUJWFNq1MMWZjTdjJ0WS/89IffaNKc++iOvffucPxQTF/gviO9+9r8kEPea1X5J2Dw=="],
+    "@discordjs/rest": ["@discordjs/rest@2.6.0", "", { "dependencies": { "@discordjs/collection": "^2.1.1", "@discordjs/util": "^1.1.1", "@sapphire/async-queue": "^1.5.3", "@sapphire/snowflake": "^3.5.3", "@vladfrangu/async_event_emitter": "^2.4.6", "discord-api-types": "^0.38.16", "magic-bytes.js": "^1.10.0", "tslib": "^2.6.3", "undici": "6.21.3" } }, "sha512-RDYrhmpB7mTvmCKcpj+pc5k7POKszS4E2O9TYc+U+Y4iaCP+r910QdO43qmpOja8LRr1RJ0b3U+CqVsnPqzf4w=="],
 
     "@discordjs/util": ["@discordjs/util@1.1.1", "", {}, "sha512-eddz6UnOBEB1oITPinyrB2Pttej49M9FZQY8NxgEvc3tq6ZICZ19m70RsmzRdDHk80O9NoYN/25AqJl8vPVf/g=="],
 
@@ -412,7 +412,7 @@
 
     "discord-api-types": ["discord-api-types@0.38.16", "", {}, "sha512-Cz42dC5WqJD17Yk0bRy7YLTJmh3NKo4FGpxZuA8MHqT0RPxKSrll5YhlODZ2z5DiEV/gpHMeTSrTFTWpSXjT1Q=="],
 
-    "discord.js": ["discord.js@14.21.0", "", { "dependencies": { "@discordjs/builders": "^1.11.2", "@discordjs/collection": "1.5.3", "@discordjs/formatters": "^0.6.1", "@discordjs/rest": "^2.5.1", "@discordjs/util": "^1.1.1", "@discordjs/ws": "^1.2.3", "@sapphire/snowflake": "3.5.3", "discord-api-types": "^0.38.1", "fast-deep-equal": "3.1.3", "lodash.snakecase": "4.1.1", "magic-bytes.js": "^1.10.0", "tslib": "^2.6.3", "undici": "6.21.3" } }, "sha512-U5w41cEmcnSfwKYlLv5RJjB8Joa+QJyRwIJz5i/eg+v2Qvv6EYpCRhN9I2Rlf0900LuqSDg8edakUATrDZQncQ=="],
+    "discord.js": ["discord.js@14.22.1", "", { "dependencies": { "@discordjs/builders": "^1.11.2", "@discordjs/collection": "1.5.3", "@discordjs/formatters": "^0.6.1", "@discordjs/rest": "^2.6.0", "@discordjs/util": "^1.1.1", "@discordjs/ws": "^1.2.3", "@sapphire/snowflake": "3.5.3", "discord-api-types": "^0.38.16", "fast-deep-equal": "3.1.3", "lodash.snakecase": "4.1.1", "magic-bytes.js": "^1.10.0", "tslib": "^2.6.3", "undici": "6.21.3" } }, "sha512-3k+Kisd/v570Jr68A1kNs7qVhNehDwDJAPe4DZ2Syt+/zobf9zEcuYFvsfIaAOgCa0BiHMfOOKQY4eYINl0z7w=="],
 
     "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
 
@@ -671,6 +671,8 @@
     "@discordjs/rest/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
 
     "@discordjs/ws/@discordjs/collection": ["@discordjs/collection@2.1.1", "", {}, "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg=="],
+
+    "@discordjs/ws/@discordjs/rest": ["@discordjs/rest@2.5.1", "", { "dependencies": { "@discordjs/collection": "^2.1.1", "@discordjs/util": "^1.1.1", "@sapphire/async-queue": "^1.5.3", "@sapphire/snowflake": "^3.5.3", "@vladfrangu/async_event_emitter": "^2.4.6", "discord-api-types": "^0.38.1", "magic-bytes.js": "^1.10.0", "tslib": "^2.6.3", "undici": "6.21.3" } }, "sha512-Tg9840IneBcbrAjcGaQzHUJWFNq1MMWZjTdjJ0WS/89IffaNKc++iOvffucPxQTF/gviO9+9r8kEPea1X5J2Dw=="],
 
     "@opentelemetry/core/@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "workspaces": ["tooling/*", "packages/*", "apps/*"],
   "dependencies": {
     "@hashira/utils": "workspace:*",
-    "discord.js": "^14.19.2",
+    "discord.js": "^14.22.1",
     "es-toolkit": "^1.36.0",
     "valibot": "^1.0.0"
   }

--- a/packages/db/prisma/migrations/20250903210352_color_role_gradient_flag/migration.sql
+++ b/packages/db/prisma/migrations/20250903210352_color_role_gradient_flag/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "colorRole" ADD COLUMN     "gradient" BOOLEAN NOT NULL DEFAULT false;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -26,6 +26,7 @@ model ColorRole {
   roleId     String
   expiration DateTime? @db.Timestamp(6)
   slots      Int
+  gradient   Boolean   @default(false)
   guild      Guild     @relation(fields: [guildId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "colorRole_guildId_guild_id_fk")
   owner      User      @relation(fields: [ownerId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "colorRole_ownerId_users_id_fk")
 


### PR DESCRIPTION
Support for optionally setting a secondary (gradient) color on roles. Only for roles which have the `gradient` flag set. Flag can be set during creation of a new color role or updated on an existing one.

Bumping discord.js to support the new `secondaryColor` API for Role colors.