### PR TITLE
feat(birthday2026): add Pasza digestion path

### DIFF
--- a/apps/bot/src/economy/managers/transferManager.ts
+++ b/apps/bot/src/economy/managers/transferManager.ts
@@ -41,21 +41,23 @@ export const addBalance = async ({
       currencyId: currency.id,
     });
 
-    await tx.wallet.update({
-      where: { id: wallet.id },
+    const transaction = await tx.transaction.create({
       data: {
-        balance: { increment: amount },
-        transactions: {
-          create: {
-            relatedUserId: fromUserId,
-            amount,
-            reason,
-            entryType: amount > 0 ? "credit" : "debit",
-            transactionType: "add",
-          },
-        },
+        walletId: wallet.id,
+        relatedUserId: fromUserId,
+        amount,
+        reason,
+        entryType: amount > 0 ? "credit" : "debit",
+        transactionType: "add",
       },
     });
+
+    const updatedWallet = await tx.wallet.update({
+      where: { id: wallet.id },
+      data: { balance: { increment: amount } },
+    });
+
+    return { transaction, wallet: updatedWallet };
   });
 };
 

--- a/apps/bot/src/economy/managers/walletManager.ts
+++ b/apps/bot/src/economy/managers/walletManager.ts
@@ -37,7 +37,7 @@ export const debitWallet = async ({
   walletId,
   amount,
   transaction,
-}: DebitWalletOptions): Promise<void> => {
+}: DebitWalletOptions) => {
   validateNonNegativeAmount(amount);
 
   const result = await prisma.wallet.updateMany({
@@ -52,7 +52,7 @@ export const debitWallet = async ({
 
   if (result.count === 0) throw new InsufficientBalanceError();
 
-  await prisma.transaction.create({
+  return prisma.transaction.create({
     data: {
       walletId,
       amount,

--- a/apps/bot/src/events/birthday2026/economyService.ts
+++ b/apps/bot/src/events/birthday2026/economyService.ts
@@ -3,33 +3,22 @@ import type {
   ExtendedPrismaClient,
   PrismaTransaction,
 } from "@hashira/db";
-import { Prisma } from "@hashira/db";
 import { nestedTransaction } from "@hashira/db/transaction";
 import { addSeconds } from "date-fns";
-import { getDefaultWallet } from "../../economy/managers/walletManager";
+import { InsufficientBalanceError } from "../../economy/economyError";
+import { debitWallet, getDefaultWallet } from "../../economy/managers/walletManager";
+import { isUniqueConstraintError } from "../../util/isUniqueConstraintError";
 
 export type Birthday2026EconomyErrorReason =
   | "config_not_found"
   | "currency_conflict"
   | "economy_not_configured"
   | "economy_already_configured"
-  | "invalid_amount"
   | "invalid_currency"
   | "invalid_digestion_delay"
-  | "invalid_source_key"
   | "insufficient_balance"
   | "member_not_found"
   | "team_wallet_not_found";
-
-const isUniqueConstraintError = (error: unknown) =>
-  error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002";
-
-const isPositiveAmount = (amount: number) => Number.isSafeInteger(amount) && amount > 0;
-
-const normalizeSourceKey = (sourceKey: string) => {
-  const normalized = sourceKey.trim();
-  return normalized.length > 0 ? normalized : null;
-};
 
 export type SetupBirthday2026EconomyResult =
   | {
@@ -59,9 +48,7 @@ export const setupBirthday2026Economy = (
   },
 ): Promise<SetupBirthday2026EconomyResult> =>
   prisma.$transaction(async (tx) => {
-    const currencyName = input.currencyName.trim();
-    const currencySymbol = input.currencySymbol.trim();
-    if (!currencyName || !currencySymbol) {
+    if (!input.currencyName || !input.currencySymbol) {
       return { ok: false, reason: "invalid_currency" };
     }
     if (
@@ -82,8 +69,8 @@ export const setupBirthday2026Economy = (
     const configuredEconomy = config.economy;
     if (configuredEconomy) {
       if (
-        configuredEconomy.currency.name !== currencyName ||
-        configuredEconomy.currency.symbol !== currencySymbol ||
+        configuredEconomy.currency.name !== input.currencyName ||
+        configuredEconomy.currency.symbol !== input.currencySymbol ||
         configuredEconomy.digestionDelaySeconds !== input.digestionDelaySeconds
       ) {
         return { ok: false, reason: "economy_already_configured" };
@@ -112,12 +99,13 @@ export const setupBirthday2026Economy = (
     const currencies = await tx.currency.findMany({
       where: {
         guildId: input.guildId,
-        OR: [{ name: currencyName }, { symbol: currencySymbol }],
+        OR: [{ name: input.currencyName }, { symbol: input.currencySymbol }],
       },
     });
     const matchingCurrency = currencies.find(
       (currency) =>
-        currency.name === currencyName && currency.symbol === currencySymbol,
+        currency.name === input.currencyName &&
+        currency.symbol === input.currencySymbol,
     );
     if (currencies.length > 0 && !matchingCurrency) {
       return { ok: false, reason: "currency_conflict" };
@@ -128,8 +116,8 @@ export const setupBirthday2026Economy = (
       (await tx.currency.create({
         data: {
           guildId: input.guildId,
-          name: currencyName,
-          symbol: currencySymbol,
+          name: input.currencyName,
+          symbol: input.currencySymbol,
           createdBy: input.createdByUserId,
         },
       }));
@@ -210,12 +198,6 @@ export const grantBirthday2026Pasza = async (
     reason: string;
   },
 ): Promise<GrantBirthday2026PaszaResult> => {
-  if (!isPositiveAmount(input.amount)) {
-    return { ok: false, reason: "invalid_amount" };
-  }
-  const sourceKey = normalizeSourceKey(input.sourceKey);
-  if (!sourceKey) return { ok: false, reason: "invalid_source_key" };
-
   const config = await prisma.birthday2026Config.findUnique({
     where: { guildId: input.guildId },
     select: {
@@ -232,7 +214,7 @@ export const grantBirthday2026Pasza = async (
   const existing = await findPersonalTransaction(prisma, {
     configId: config.id,
     source: "staffGrant",
-    sourceKey,
+    sourceKey: input.sourceKey,
   });
   if (existing) return { ok: true, created: false, ...existing };
 
@@ -270,7 +252,7 @@ export const grantBirthday2026Pasza = async (
           userId: input.userId,
           transactionId: transaction.id,
           source: "staffGrant",
-          sourceKey,
+          sourceKey: input.sourceKey,
           createdByUserId: input.createdByUserId,
         },
       });
@@ -290,7 +272,7 @@ export const grantBirthday2026Pasza = async (
     const duplicate = await findPersonalTransaction(prisma, {
       configId: config.id,
       source: "staffGrant",
-      sourceKey,
+      sourceKey: input.sourceKey,
     });
     if (!duplicate) throw error;
     return { ok: true, created: false, ...duplicate };
@@ -352,12 +334,6 @@ export const feedBirthday2026Pig = async (
     scheduleDigestion: ScheduleDigestion;
   },
 ): Promise<FeedBirthday2026PigResult> => {
-  if (!isPositiveAmount(input.amount)) {
-    return { ok: false, reason: "invalid_amount" };
-  }
-  const sourceKey = normalizeSourceKey(input.sourceKey);
-  if (!sourceKey) return { ok: false, reason: "invalid_source_key" };
-
   const config = await prisma.birthday2026Config.findUnique({
     where: { guildId: input.guildId },
     select: {
@@ -376,7 +352,7 @@ export const feedBirthday2026Pig = async (
   }
   const { currencyId, digestionDelaySeconds } = config.economy;
 
-  const duplicate = await findFeedResult(prisma, config.id, sourceKey);
+  const duplicate = await findFeedResult(prisma, config.id, input.sourceKey);
   if (duplicate) return duplicate;
 
   const membership = await prisma.birthday2026MemberState.findUnique({
@@ -401,21 +377,13 @@ export const feedBirthday2026Pig = async (
         userId: input.userId,
         currencyId,
       });
-      const debit = await tx.wallet.updateMany({
-        where: { id: wallet.id, balance: { gte: input.amount } },
-        data: { balance: { decrement: input.amount } },
-      });
-      if (debit.count === 0) {
-        return { ok: false, reason: "insufficient_balance" };
-      }
-
-      const personalTransaction = await tx.transaction.create({
-        data: {
-          walletId: wallet.id,
-          amount: input.amount,
+      const personalTransaction = await debitWallet({
+        prisma: tx,
+        walletId: wallet.id,
+        amount: input.amount,
+        transaction: {
           reason: input.reason,
           transactionType: "transfer",
-          entryType: "debit",
         },
       });
       await tx.birthday2026PersonalTransaction.create({
@@ -424,7 +392,7 @@ export const feedBirthday2026Pig = async (
           userId: input.userId,
           transactionId: personalTransaction.id,
           source: "feed",
-          sourceKey,
+          sourceKey: input.sourceKey,
         },
       });
 
@@ -436,7 +404,7 @@ export const feedBirthday2026Pig = async (
           personalTransactionId: personalTransaction.id,
           amount: input.amount,
           remainingAmount: input.amount,
-          sourceKey,
+          sourceKey: input.sourceKey,
           digestAt: addSeconds(input.acceptedAt, digestionDelaySeconds),
         },
       });
@@ -453,7 +421,7 @@ export const feedBirthday2026Pig = async (
           entryType: "credit",
           amount: input.amount,
           reason: input.reason,
-          sourceKey,
+          sourceKey: input.sourceKey,
         },
       });
       await input.scheduleDigestion(tx, batch);
@@ -471,8 +439,11 @@ export const feedBirthday2026Pig = async (
       };
     });
   } catch (error) {
+    if (error instanceof InsufficientBalanceError) {
+      return { ok: false, reason: "insufficient_balance" };
+    }
     if (!isUniqueConstraintError(error)) throw error;
-    const existing = await findFeedResult(prisma, config.id, sourceKey);
+    const existing = await findFeedResult(prisma, config.id, input.sourceKey);
     if (!existing) throw error;
     return existing;
   }

--- a/apps/bot/src/events/birthday2026/economyService.ts
+++ b/apps/bot/src/events/birthday2026/economyService.ts
@@ -1,13 +1,13 @@
-import type {
-  Birthday2026FeedBatch,
-  ExtendedPrismaClient,
-  PrismaTransaction,
+import {
+  type Birthday2026FeedBatch,
+  type ExtendedPrismaClient,
+  isUniqueConstraintError,
+  type PrismaTransaction,
 } from "@hashira/db";
 import { nestedTransaction } from "@hashira/db/transaction";
 import { addSeconds } from "date-fns";
 import { InsufficientBalanceError } from "../../economy/economyError";
 import { debitWallet, getDefaultWallet } from "../../economy/managers/walletManager";
-import { isUniqueConstraintError } from "../../util/isUniqueConstraintError";
 
 export type Birthday2026EconomyErrorReason =
   | "config_not_found"

--- a/apps/bot/src/events/birthday2026/economyService.ts
+++ b/apps/bot/src/events/birthday2026/economyService.ts
@@ -1,0 +1,645 @@
+import type {
+  Birthday2026FeedBatch,
+  ExtendedPrismaClient,
+  PrismaTransaction,
+} from "@hashira/db";
+import { Prisma } from "@hashira/db";
+import { nestedTransaction } from "@hashira/db/transaction";
+import { addSeconds } from "date-fns";
+import { getDefaultWallet } from "../../economy/managers/walletManager";
+
+export type Birthday2026EconomyErrorReason =
+  | "config_not_found"
+  | "currency_conflict"
+  | "economy_not_configured"
+  | "economy_already_configured"
+  | "invalid_amount"
+  | "invalid_currency"
+  | "invalid_digestion_delay"
+  | "invalid_source_key"
+  | "insufficient_balance"
+  | "member_not_found"
+  | "team_wallet_not_found";
+
+const isUniqueConstraintError = (error: unknown) =>
+  error instanceof Prisma.PrismaClientKnownRequestError && error.code === "P2002";
+
+const isPositiveAmount = (amount: number) => Number.isSafeInteger(amount) && amount > 0;
+
+const normalizeSourceKey = (sourceKey: string) => {
+  const normalized = sourceKey.trim();
+  return normalized.length > 0 ? normalized : null;
+};
+
+export type SetupBirthday2026EconomyResult =
+  | {
+      ok: true;
+      configId: number;
+      currencyId: number;
+      teamWalletCount: number;
+    }
+  | {
+      ok: false;
+      reason:
+        | "config_not_found"
+        | "currency_conflict"
+        | "economy_already_configured"
+        | "invalid_currency"
+        | "invalid_digestion_delay";
+    };
+
+export const setupBirthday2026Economy = (
+  prisma: ExtendedPrismaClient,
+  input: {
+    guildId: string;
+    currencyName: string;
+    currencySymbol: string;
+    digestionDelaySeconds: number;
+    createdByUserId: string;
+  },
+): Promise<SetupBirthday2026EconomyResult> =>
+  prisma.$transaction(async (tx) => {
+    const currencyName = input.currencyName.trim();
+    const currencySymbol = input.currencySymbol.trim();
+    if (!currencyName || !currencySymbol) {
+      return { ok: false, reason: "invalid_currency" };
+    }
+    if (
+      !Number.isSafeInteger(input.digestionDelaySeconds) ||
+      input.digestionDelaySeconds < 0
+    ) {
+      return { ok: false, reason: "invalid_digestion_delay" };
+    }
+
+    const config = await tx.birthday2026Config.findUnique({
+      where: { guildId: input.guildId },
+      include: {
+        economy: { include: { currency: true } },
+        teams: { select: { id: true, wallet: { select: { id: true } } } },
+      },
+    });
+    if (!config) return { ok: false, reason: "config_not_found" };
+    const configuredEconomy = config.economy;
+    if (configuredEconomy) {
+      if (
+        configuredEconomy.currency.name !== currencyName ||
+        configuredEconomy.currency.symbol !== currencySymbol ||
+        configuredEconomy.digestionDelaySeconds !== input.digestionDelaySeconds
+      ) {
+        return { ok: false, reason: "economy_already_configured" };
+      }
+
+      const missingTeams = config.teams.filter((team) => !team.wallet);
+      if (missingTeams.length > 0) {
+        await tx.birthday2026TeamWallet.createMany({
+          data: missingTeams.map((team) => ({
+            teamConfigId: team.id,
+            currencyId: configuredEconomy.currencyId,
+            balance: 0,
+            permanentWeight: 0,
+          })),
+        });
+      }
+
+      return {
+        ok: true,
+        configId: config.id,
+        currencyId: configuredEconomy.currencyId,
+        teamWalletCount: config.teams.length,
+      };
+    }
+
+    const currencies = await tx.currency.findMany({
+      where: {
+        guildId: input.guildId,
+        OR: [{ name: currencyName }, { symbol: currencySymbol }],
+      },
+    });
+    const matchingCurrency = currencies.find(
+      (currency) =>
+        currency.name === currencyName && currency.symbol === currencySymbol,
+    );
+    if (currencies.length > 0 && !matchingCurrency) {
+      return { ok: false, reason: "currency_conflict" };
+    }
+
+    const currency =
+      matchingCurrency ??
+      (await tx.currency.create({
+        data: {
+          guildId: input.guildId,
+          name: currencyName,
+          symbol: currencySymbol,
+          createdBy: input.createdByUserId,
+        },
+      }));
+
+    await tx.birthday2026EconomyConfig.create({
+      data: {
+        configId: config.id,
+        currencyId: currency.id,
+        digestionDelaySeconds: input.digestionDelaySeconds,
+      },
+    });
+    await tx.birthday2026TeamWallet.createMany({
+      data: config.teams.map((team) => ({
+        teamConfigId: team.id,
+        currencyId: currency.id,
+        balance: 0,
+        permanentWeight: 0,
+      })),
+    });
+
+    return {
+      ok: true,
+      configId: config.id,
+      currencyId: currency.id,
+      teamWalletCount: config.teams.length,
+    };
+  });
+
+const findPersonalTransaction = async (
+  prisma: PrismaTransaction,
+  input: {
+    configId: number;
+    source: "feed" | "staffGrant";
+    sourceKey: string;
+  },
+) => {
+  const reference = await prisma.birthday2026PersonalTransaction.findUnique({
+    where: {
+      configId_source_sourceKey: input,
+    },
+    include: {
+      transaction: {
+        include: { wallet: { select: { id: true, balance: true } } },
+      },
+    },
+  });
+  if (!reference) return null;
+
+  return {
+    amount: reference.transaction.amount,
+    userId: reference.userId,
+    walletId: reference.transaction.wallet.id,
+    walletBalance: reference.transaction.wallet.balance,
+    transactionId: reference.transactionId,
+  };
+};
+
+export type GrantBirthday2026PaszaResult =
+  | {
+      ok: true;
+      created: boolean;
+      amount: number;
+      userId: string;
+      walletId: number;
+      walletBalance: number;
+      transactionId: number;
+    }
+  | { ok: false; reason: Birthday2026EconomyErrorReason };
+
+export const grantBirthday2026Pasza = async (
+  prisma: ExtendedPrismaClient,
+  input: {
+    guildId: string;
+    userId: string;
+    amount: number;
+    sourceKey: string;
+    createdByUserId: string;
+    reason: string;
+  },
+): Promise<GrantBirthday2026PaszaResult> => {
+  if (!isPositiveAmount(input.amount)) {
+    return { ok: false, reason: "invalid_amount" };
+  }
+  const sourceKey = normalizeSourceKey(input.sourceKey);
+  if (!sourceKey) return { ok: false, reason: "invalid_source_key" };
+
+  const config = await prisma.birthday2026Config.findUnique({
+    where: { guildId: input.guildId },
+    select: {
+      id: true,
+      economy: { select: { currencyId: true } },
+    },
+  });
+  if (!config) return { ok: false, reason: "config_not_found" };
+  if (!config.economy) {
+    return { ok: false, reason: "economy_not_configured" };
+  }
+  const currencyId = config.economy.currencyId;
+
+  const existing = await findPersonalTransaction(prisma, {
+    configId: config.id,
+    source: "staffGrant",
+    sourceKey,
+  });
+  if (existing) return { ok: true, created: false, ...existing };
+
+  const membership = await prisma.birthday2026MemberState.findUnique({
+    where: { configId_userId: { configId: config.id, userId: input.userId } },
+    select: { id: true },
+  });
+  if (!membership) return { ok: false, reason: "member_not_found" };
+
+  try {
+    return await prisma.$transaction(async (tx) => {
+      const wallet = await getDefaultWallet({
+        prisma: nestedTransaction(tx),
+        guildId: input.guildId,
+        userId: input.userId,
+        currencyId,
+      });
+      const updatedWallet = await tx.wallet.update({
+        where: { id: wallet.id },
+        data: { balance: { increment: input.amount } },
+      });
+      const transaction = await tx.transaction.create({
+        data: {
+          walletId: wallet.id,
+          relatedUserId: input.createdByUserId,
+          amount: input.amount,
+          reason: input.reason,
+          transactionType: "add",
+          entryType: "credit",
+        },
+      });
+      await tx.birthday2026PersonalTransaction.create({
+        data: {
+          configId: config.id,
+          userId: input.userId,
+          transactionId: transaction.id,
+          source: "staffGrant",
+          sourceKey,
+          createdByUserId: input.createdByUserId,
+        },
+      });
+
+      return {
+        ok: true,
+        created: true,
+        amount: input.amount,
+        userId: input.userId,
+        walletId: wallet.id,
+        walletBalance: updatedWallet.balance,
+        transactionId: transaction.id,
+      };
+    });
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error;
+    const duplicate = await findPersonalTransaction(prisma, {
+      configId: config.id,
+      source: "staffGrant",
+      sourceKey,
+    });
+    if (!duplicate) throw error;
+    return { ok: true, created: false, ...duplicate };
+  }
+};
+
+type ScheduleDigestion = (
+  tx: PrismaTransaction,
+  batch: Pick<Birthday2026FeedBatch, "digestAt" | "id">,
+) => Promise<void>;
+
+export type FeedBirthday2026PigResult =
+  | {
+      ok: true;
+      created: boolean;
+      batch: Birthday2026FeedBatch;
+      personalBalance: number;
+      teamBalance: number;
+    }
+  | {
+      ok: false;
+      reason: Birthday2026EconomyErrorReason;
+    };
+
+const findFeedResult = async (
+  prisma: PrismaTransaction,
+  configId: number,
+  sourceKey: string,
+): Promise<Extract<FeedBirthday2026PigResult, { ok: true }> | null> => {
+  const batch = await prisma.birthday2026FeedBatch.findUnique({
+    where: { configId_sourceKey: { configId, sourceKey } },
+    include: {
+      wallet: { select: { balance: true } },
+      personalTransaction: {
+        include: { wallet: { select: { balance: true } } },
+      },
+    },
+  });
+  if (!batch) return null;
+
+  return {
+    ok: true,
+    created: false,
+    batch,
+    personalBalance: batch.personalTransaction.wallet.balance,
+    teamBalance: batch.wallet.balance,
+  };
+};
+
+export const feedBirthday2026Pig = async (
+  prisma: ExtendedPrismaClient,
+  input: {
+    guildId: string;
+    userId: string;
+    amount: number;
+    sourceKey: string;
+    acceptedAt: Date;
+    reason: string;
+    scheduleDigestion: ScheduleDigestion;
+  },
+): Promise<FeedBirthday2026PigResult> => {
+  if (!isPositiveAmount(input.amount)) {
+    return { ok: false, reason: "invalid_amount" };
+  }
+  const sourceKey = normalizeSourceKey(input.sourceKey);
+  if (!sourceKey) return { ok: false, reason: "invalid_source_key" };
+
+  const config = await prisma.birthday2026Config.findUnique({
+    where: { guildId: input.guildId },
+    select: {
+      id: true,
+      economy: {
+        select: {
+          currencyId: true,
+          digestionDelaySeconds: true,
+        },
+      },
+    },
+  });
+  if (!config) return { ok: false, reason: "config_not_found" };
+  if (!config.economy) {
+    return { ok: false, reason: "economy_not_configured" };
+  }
+  const { currencyId, digestionDelaySeconds } = config.economy;
+
+  const duplicate = await findFeedResult(prisma, config.id, sourceKey);
+  if (duplicate) return duplicate;
+
+  const membership = await prisma.birthday2026MemberState.findUnique({
+    where: { configId_userId: { configId: config.id, userId: input.userId } },
+    include: {
+      teamConfig: {
+        include: { wallet: true },
+      },
+    },
+  });
+  if (!membership) return { ok: false, reason: "member_not_found" };
+  const teamWallet = membership.teamConfig.wallet;
+  if (!teamWallet || teamWallet.currencyId !== currencyId) {
+    return { ok: false, reason: "team_wallet_not_found" };
+  }
+
+  try {
+    return await prisma.$transaction(async (tx) => {
+      const wallet = await getDefaultWallet({
+        prisma: nestedTransaction(tx),
+        guildId: input.guildId,
+        userId: input.userId,
+        currencyId,
+      });
+      const debit = await tx.wallet.updateMany({
+        where: { id: wallet.id, balance: { gte: input.amount } },
+        data: { balance: { decrement: input.amount } },
+      });
+      if (debit.count === 0) {
+        return { ok: false, reason: "insufficient_balance" };
+      }
+
+      const personalTransaction = await tx.transaction.create({
+        data: {
+          walletId: wallet.id,
+          amount: input.amount,
+          reason: input.reason,
+          transactionType: "transfer",
+          entryType: "debit",
+        },
+      });
+      await tx.birthday2026PersonalTransaction.create({
+        data: {
+          configId: config.id,
+          userId: input.userId,
+          transactionId: personalTransaction.id,
+          source: "feed",
+          sourceKey,
+        },
+      });
+
+      const batch = await tx.birthday2026FeedBatch.create({
+        data: {
+          configId: config.id,
+          walletId: teamWallet.id,
+          userId: input.userId,
+          personalTransactionId: personalTransaction.id,
+          amount: input.amount,
+          remainingAmount: input.amount,
+          sourceKey,
+          digestAt: addSeconds(input.acceptedAt, digestionDelaySeconds),
+        },
+      });
+      const updatedTeamWallet = await tx.birthday2026TeamWallet.update({
+        where: { id: teamWallet.id },
+        data: { balance: { increment: input.amount } },
+      });
+      await tx.birthday2026TeamWalletTransaction.create({
+        data: {
+          walletId: teamWallet.id,
+          feedBatchId: batch.id,
+          personalTransactionId: personalTransaction.id,
+          source: "feed",
+          entryType: "credit",
+          amount: input.amount,
+          reason: input.reason,
+          sourceKey,
+        },
+      });
+      await input.scheduleDigestion(tx, batch);
+
+      const updatedPersonalWallet = await tx.wallet.findUniqueOrThrow({
+        where: { id: wallet.id },
+        select: { balance: true },
+      });
+      return {
+        ok: true,
+        created: true,
+        batch,
+        personalBalance: updatedPersonalWallet.balance,
+        teamBalance: updatedTeamWallet.balance,
+      };
+    });
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error;
+    const existing = await findFeedResult(prisma, config.id, sourceKey);
+    if (!existing) throw error;
+    return existing;
+  }
+};
+
+class TeamWalletInvariantError extends Error {}
+
+export type DigestBirthday2026FeedBatchResult =
+  | {
+      ok: true;
+      digested: boolean;
+      amount: number;
+      permanentWeight: number;
+      teamBalance: number;
+    }
+  | {
+      ok: false;
+      reason: "batch_not_found" | "not_due" | "team_wallet_balance_mismatch";
+    };
+
+export const digestBirthday2026FeedBatch = async (
+  prisma: ExtendedPrismaClient,
+  input: {
+    batchId: number;
+    processedAt: Date;
+    reason: string;
+  },
+): Promise<DigestBirthday2026FeedBatchResult> => {
+  try {
+    return await prisma.$transaction(async (tx) => {
+      const batch = await tx.birthday2026FeedBatch.findUnique({
+        where: { id: input.batchId },
+        include: { wallet: true },
+      });
+      if (!batch) return { ok: false, reason: "batch_not_found" };
+      if (batch.digestedAt) {
+        return {
+          ok: true,
+          digested: false,
+          amount: batch.amount,
+          permanentWeight: batch.wallet.permanentWeight,
+          teamBalance: batch.wallet.balance,
+        };
+      }
+      if (input.processedAt < batch.digestAt) {
+        return { ok: false, reason: "not_due" };
+      }
+
+      const claim = await tx.birthday2026FeedBatch.updateMany({
+        where: { id: batch.id, digestedAt: null },
+        data: { digestedAt: input.processedAt, remainingAmount: 0 },
+      });
+      if (claim.count === 0) {
+        const currentWallet = await tx.birthday2026TeamWallet.findUniqueOrThrow({
+          where: { id: batch.walletId },
+        });
+        return {
+          ok: true,
+          digested: false,
+          amount: batch.amount,
+          permanentWeight: currentWallet.permanentWeight,
+          teamBalance: currentWallet.balance,
+        };
+      }
+
+      const walletUpdate = await tx.birthday2026TeamWallet.updateMany({
+        where: {
+          id: batch.walletId,
+          balance: { gte: batch.remainingAmount },
+        },
+        data: {
+          balance: { decrement: batch.remainingAmount },
+          permanentWeight: { increment: batch.remainingAmount },
+        },
+      });
+      if (walletUpdate.count === 0) throw new TeamWalletInvariantError();
+
+      await tx.birthday2026TeamWalletTransaction.create({
+        data: {
+          walletId: batch.walletId,
+          feedBatchId: batch.id,
+          source: "digestion",
+          entryType: "debit",
+          amount: batch.remainingAmount,
+          reason: input.reason,
+          sourceKey: batch.sourceKey,
+        },
+      });
+      const wallet = await tx.birthday2026TeamWallet.findUniqueOrThrow({
+        where: { id: batch.walletId },
+      });
+
+      return {
+        ok: true,
+        digested: true,
+        amount: batch.remainingAmount,
+        permanentWeight: wallet.permanentWeight,
+        teamBalance: wallet.balance,
+      };
+    });
+  } catch (error) {
+    if (error instanceof TeamWalletInvariantError) {
+      return { ok: false, reason: "team_wallet_balance_mismatch" };
+    }
+    throw error;
+  }
+};
+
+export type Birthday2026TeamEconomyStatus = {
+  teamConfigId: number;
+  teamName: string;
+  balance: number | null;
+  unresolvedFeed: number | null;
+  permanentWeight: number | null;
+  reconciled: boolean;
+};
+
+export const getBirthday2026EconomyStatus = async (
+  prisma: PrismaTransaction,
+  guildId: string,
+): Promise<Birthday2026TeamEconomyStatus[] | null> => {
+  const config = await prisma.birthday2026Config.findUnique({
+    where: { guildId },
+    include: {
+      economy: true,
+      teams: {
+        include: {
+          team: true,
+          wallet: {
+            include: {
+              feedBatches: {
+                where: { digestedAt: null },
+                select: { remainingAmount: true },
+              },
+            },
+          },
+        },
+        orderBy: { id: "asc" },
+      },
+    },
+  });
+  if (!config?.economy) {
+    return null;
+  }
+
+  return config.teams.map((team) => {
+    if (!team.wallet) {
+      return {
+        teamConfigId: team.id,
+        teamName: team.team.name,
+        balance: null,
+        unresolvedFeed: null,
+        permanentWeight: null,
+        reconciled: false,
+      };
+    }
+    const unresolvedFeed = team.wallet.feedBatches.reduce(
+      (sum, batch) => sum + batch.remainingAmount,
+      0,
+    );
+    return {
+      teamConfigId: team.id,
+      teamName: team.team.name,
+      balance: team.wallet.balance,
+      unresolvedFeed,
+      permanentWeight: team.wallet.permanentWeight,
+      reconciled: team.wallet.balance === unresolvedFeed,
+    };
+  });
+};

--- a/apps/bot/src/events/birthday2026/economyService.ts
+++ b/apps/bot/src/events/birthday2026/economyService.ts
@@ -1,12 +1,12 @@
-import {
-  type Birthday2026FeedBatch,
-  type ExtendedPrismaClient,
-  isUniqueConstraintError,
-  type PrismaTransaction,
+import type {
+  Birthday2026FeedBatch,
+  ExtendedPrismaClient,
+  PrismaTransaction,
 } from "@hashira/db";
 import { nestedTransaction } from "@hashira/db/transaction";
 import { addSeconds } from "date-fns";
 import { InsufficientBalanceError } from "../../economy/economyError";
+import { addBalance } from "../../economy/managers/transferManager";
 import { debitWallet, getDefaultWallet } from "../../economy/managers/walletManager";
 
 export type Birthday2026EconomyErrorReason =
@@ -224,59 +224,38 @@ export const grantBirthday2026Pasza = async (
   });
   if (!membership) return { ok: false, reason: "member_not_found" };
 
-  try {
-    return await prisma.$transaction(async (tx) => {
-      const wallet = await getDefaultWallet({
-        prisma: nestedTransaction(tx),
-        guildId: input.guildId,
-        userId: input.userId,
-        currencyId,
-      });
-      const updatedWallet = await tx.wallet.update({
-        where: { id: wallet.id },
-        data: { balance: { increment: input.amount } },
-      });
-      const transaction = await tx.transaction.create({
-        data: {
-          walletId: wallet.id,
-          relatedUserId: input.createdByUserId,
-          amount: input.amount,
-          reason: input.reason,
-          transactionType: "add",
-          entryType: "credit",
-        },
-      });
-      await tx.birthday2026PersonalTransaction.create({
-        data: {
-          configId: config.id,
-          userId: input.userId,
-          transactionId: transaction.id,
-          source: "staffGrant",
-          sourceKey: input.sourceKey,
-          createdByUserId: input.createdByUserId,
-        },
-      });
+  return prisma.$transaction(async (tx) => {
+    const { transaction, wallet } = await addBalance({
+      prisma: nestedTransaction(tx),
+      fromUserId: input.createdByUserId,
+      toUserId: input.userId,
+      guildId: input.guildId,
+      amount: input.amount,
+      reason: input.reason,
+      currencyId,
+    });
 
-      return {
-        ok: true,
-        created: true,
-        amount: input.amount,
+    await tx.birthday2026PersonalTransaction.create({
+      data: {
+        configId: config.id,
         userId: input.userId,
-        walletId: wallet.id,
-        walletBalance: updatedWallet.balance,
         transactionId: transaction.id,
-      };
+        source: "staffGrant",
+        sourceKey: input.sourceKey,
+        createdByUserId: input.createdByUserId,
+      },
     });
-  } catch (error) {
-    if (!isUniqueConstraintError(error)) throw error;
-    const duplicate = await findPersonalTransaction(prisma, {
-      configId: config.id,
-      source: "staffGrant",
-      sourceKey: input.sourceKey,
-    });
-    if (!duplicate) throw error;
-    return { ok: true, created: false, ...duplicate };
-  }
+
+    return {
+      ok: true,
+      created: true,
+      amount: input.amount,
+      userId: input.userId,
+      walletId: wallet.id,
+      walletBalance: wallet.balance,
+      transactionId: transaction.id,
+    };
+  });
 };
 
 type ScheduleDigestion = (
@@ -377,6 +356,7 @@ export const feedBirthday2026Pig = async (
         userId: input.userId,
         currencyId,
       });
+
       const personalTransaction = await debitWallet({
         prisma: tx,
         walletId: wallet.id,
@@ -386,6 +366,7 @@ export const feedBirthday2026Pig = async (
           transactionType: "transfer",
         },
       });
+
       await tx.birthday2026PersonalTransaction.create({
         data: {
           configId: config.id,
@@ -442,14 +423,9 @@ export const feedBirthday2026Pig = async (
     if (error instanceof InsufficientBalanceError) {
       return { ok: false, reason: "insufficient_balance" };
     }
-    if (!isUniqueConstraintError(error)) throw error;
-    const existing = await findFeedResult(prisma, config.id, input.sourceKey);
-    if (!existing) throw error;
-    return existing;
+    throw error;
   }
 };
-
-class TeamWalletInvariantError extends Error {}
 
 export type DigestBirthday2026FeedBatchResult =
   | {
@@ -471,86 +447,79 @@ export const digestBirthday2026FeedBatch = async (
     processedAt: Date;
     reason: string;
   },
-): Promise<DigestBirthday2026FeedBatchResult> => {
-  try {
-    return await prisma.$transaction(async (tx) => {
-      const batch = await tx.birthday2026FeedBatch.findUnique({
-        where: { id: input.batchId },
-        include: { wallet: true },
-      });
-      if (!batch) return { ok: false, reason: "batch_not_found" };
-      if (batch.digestedAt) {
-        return {
-          ok: true,
-          digested: false,
-          amount: batch.amount,
-          permanentWeight: batch.wallet.permanentWeight,
-          teamBalance: batch.wallet.balance,
-        };
-      }
-      if (input.processedAt < batch.digestAt) {
-        return { ok: false, reason: "not_due" };
-      }
+): Promise<DigestBirthday2026FeedBatchResult> =>
+  prisma.$transaction(async (tx) => {
+    const batch = await tx.birthday2026FeedBatch.findUnique({
+      where: { id: input.batchId },
+      include: { wallet: true },
+    });
 
-      const claim = await tx.birthday2026FeedBatch.updateMany({
-        where: { id: batch.id, digestedAt: null },
-        data: { digestedAt: input.processedAt, remainingAmount: 0 },
-      });
-      if (claim.count === 0) {
-        const currentWallet = await tx.birthday2026TeamWallet.findUniqueOrThrow({
-          where: { id: batch.walletId },
-        });
-        return {
-          ok: true,
-          digested: false,
-          amount: batch.amount,
-          permanentWeight: currentWallet.permanentWeight,
-          teamBalance: currentWallet.balance,
-        };
-      }
+    if (!batch) return { ok: false, reason: "batch_not_found" };
 
-      const walletUpdate = await tx.birthday2026TeamWallet.updateMany({
-        where: {
-          id: batch.walletId,
-          balance: { gte: batch.remainingAmount },
-        },
-        data: {
-          balance: { decrement: batch.remainingAmount },
-          permanentWeight: { increment: batch.remainingAmount },
-        },
-      });
-      if (walletUpdate.count === 0) throw new TeamWalletInvariantError();
+    if (batch.digestedAt) {
+      return {
+        ok: true,
+        digested: false,
+        amount: batch.amount,
+        permanentWeight: batch.wallet.permanentWeight,
+        teamBalance: batch.wallet.balance,
+      };
+    }
 
-      await tx.birthday2026TeamWalletTransaction.create({
-        data: {
-          walletId: batch.walletId,
-          feedBatchId: batch.id,
-          source: "digestion",
-          entryType: "debit",
-          amount: batch.remainingAmount,
-          reason: input.reason,
-          sourceKey: batch.sourceKey,
-        },
-      });
-      const wallet = await tx.birthday2026TeamWallet.findUniqueOrThrow({
+    if (input.processedAt < batch.digestAt) {
+      return { ok: false, reason: "not_due" };
+    }
+
+    if (batch.wallet.balance < batch.remainingAmount) {
+      return { ok: false, reason: "team_wallet_balance_mismatch" };
+    }
+
+    const claim = await tx.birthday2026FeedBatch.updateMany({
+      where: { id: batch.id, digestedAt: null },
+      data: { digestedAt: input.processedAt, remainingAmount: 0 },
+    });
+
+    if (claim.count === 0) {
+      const currentWallet = await tx.birthday2026TeamWallet.findUniqueOrThrow({
         where: { id: batch.walletId },
       });
 
       return {
         ok: true,
-        digested: true,
-        amount: batch.remainingAmount,
-        permanentWeight: wallet.permanentWeight,
-        teamBalance: wallet.balance,
+        digested: false,
+        amount: batch.amount,
+        permanentWeight: currentWallet.permanentWeight,
+        teamBalance: currentWallet.balance,
       };
-    });
-  } catch (error) {
-    if (error instanceof TeamWalletInvariantError) {
-      return { ok: false, reason: "team_wallet_balance_mismatch" };
     }
-    throw error;
-  }
-};
+
+    const wallet = await tx.birthday2026TeamWallet.update({
+      where: { id: batch.walletId },
+      data: {
+        balance: { decrement: batch.remainingAmount },
+        permanentWeight: { increment: batch.remainingAmount },
+      },
+    });
+
+    await tx.birthday2026TeamWalletTransaction.create({
+      data: {
+        walletId: batch.walletId,
+        feedBatchId: batch.id,
+        source: "digestion",
+        entryType: "debit",
+        amount: batch.remainingAmount,
+        reason: input.reason,
+        sourceKey: batch.sourceKey,
+      },
+    });
+    return {
+      ok: true,
+      digested: true,
+      amount: batch.remainingAmount,
+      permanentWeight: wallet.permanentWeight,
+      teamBalance: wallet.balance,
+    };
+  });
 
 export type Birthday2026TeamEconomyStatus = {
   teamConfigId: number;

--- a/apps/bot/src/events/birthday2026/eventState.ts
+++ b/apps/bot/src/events/birthday2026/eventState.ts
@@ -2,12 +2,10 @@ import type { Birthday2026Config } from "@hashira/db";
 
 const MILLISECONDS_PER_EVENT_DAY = 24 * 60 * 60 * 1000;
 
-type EventWindow = Pick<
-  Birthday2026Config,
-  "enabled" | "eventEndAt" | "eventStartAt" | "visible"
->;
-
-export const getBirthday2026EventState = (config: EventWindow | null, now: Date) => {
+export const getBirthday2026EventState = (
+  config: Birthday2026Config | null,
+  now: Date,
+) => {
   if (!config) return "not_configured";
   if (!config.visible) return "hidden";
   if (!config.enabled) return "disabled";
@@ -17,7 +15,7 @@ export const getBirthday2026EventState = (config: EventWindow | null, now: Date)
 };
 
 export const getBirthday2026RegistrationState = (
-  config: EventWindow | null,
+  config: Birthday2026Config | null,
   now: Date,
 ) => {
   if (!config) return "not_configured";
@@ -26,10 +24,7 @@ export const getBirthday2026RegistrationState = (
   return "open";
 };
 
-export const getBirthday2026EventDayIndex = (
-  config: Pick<Birthday2026Config, "eventEndAt" | "eventStartAt">,
-  at: Date,
-) => {
+export const getBirthday2026EventDayIndex = (config: Birthday2026Config, at: Date) => {
   if (at < config.eventStartAt || at >= config.eventEndAt) return null;
   return Math.floor(
     (at.getTime() - config.eventStartAt.getTime()) / MILLISECONDS_PER_EVENT_DAY,

--- a/apps/bot/src/events/birthday2026/index.ts
+++ b/apps/bot/src/events/birthday2026/index.ts
@@ -47,29 +47,17 @@ const teamErrorMessages = {
   team_not_found: "Nie znaleziono wskazanej drużyny.",
 };
 
-const replyWithTeamError = (
-  itx: Parameters<typeof errorFollowUp>[0],
-  reason: keyof typeof teamErrorMessages,
-) => errorFollowUp(itx, teamErrorMessages[reason]);
-
 const economyErrorMessages: Record<Birthday2026EconomyErrorReason, string> = {
   config_not_found: "Event urodzinowy nie jest jeszcze skonfigurowany.",
   currency_conflict: "Nazwa albo symbol waluty są już używane na tym serwerze.",
   economy_already_configured: "Ekonomia jest już skonfigurowana z innymi wartościami.",
   economy_not_configured: "Najpierw skonfiguruj ekonomię eventu.",
   insufficient_balance: "Użytkownik nie ma wystarczającej ilości Paszy.",
-  invalid_amount: "Ilość musi być dodatnią liczbą całkowitą.",
   invalid_currency: "Nazwa i symbol waluty nie mogą być puste.",
   invalid_digestion_delay: "Czas trawienia musi być nieujemną liczbą sekund.",
-  invalid_source_key: "Klucz źródła nie może być pusty.",
   member_not_found: "Ten użytkownik nie należy do eventu.",
   team_wallet_not_found: "Drużyna nie ma poprawnie skonfigurowanego portfela.",
 };
-
-const replyWithEconomyError = (
-  itx: Parameters<typeof errorFollowUp>[0],
-  reason: Birthday2026EconomyErrorReason,
-) => errorFollowUp(itx, economyErrorMessages[reason]);
 
 const findTeamByRole = async (
   prisma: Parameters<typeof findBirthday2026Teams>[0],
@@ -268,7 +256,7 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
                 createdByUserId: itx.user.id,
               });
               if (!result.ok) {
-                await replyWithEconomyError(itx, result.reason);
+                await errorFollowUp(itx, economyErrorMessages[result.reason]);
                 return;
               }
 
@@ -308,7 +296,7 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
               reason,
             });
             if (!result.ok) {
-              await replyWithEconomyError(itx, result.reason);
+              await errorFollowUp(itx, economyErrorMessages[result.reason]);
               return;
             }
 
@@ -353,7 +341,7 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
                   ),
               });
               if (!result.ok) {
-                await replyWithEconomyError(itx, result.reason);
+                await errorFollowUp(itx, economyErrorMessages[result.reason]);
                 return;
               }
 

--- a/apps/bot/src/events/birthday2026/index.ts
+++ b/apps/bot/src/events/birthday2026/index.ts
@@ -13,6 +13,13 @@ import { errorFollowUp } from "../../util/errorFollowUp";
 import { getColor } from "../../util/getColor";
 import { findBirthday2026Config, upsertBirthday2026Config } from "./configService";
 import {
+  type Birthday2026EconomyErrorReason,
+  feedBirthday2026Pig,
+  getBirthday2026EconomyStatus,
+  grantBirthday2026Pasza,
+  setupBirthday2026Economy,
+} from "./economyService";
+import {
   getBirthday2026EventState,
   getBirthday2026RegistrationState,
 } from "./eventState";
@@ -39,6 +46,30 @@ const teamErrorMessages = {
   team_already_exists: "Drużyna o tej nazwie już istnieje na serwerze.",
   team_not_found: "Nie znaleziono wskazanej drużyny.",
 };
+
+const replyWithTeamError = (
+  itx: Parameters<typeof errorFollowUp>[0],
+  reason: keyof typeof teamErrorMessages,
+) => errorFollowUp(itx, teamErrorMessages[reason]);
+
+const economyErrorMessages: Record<Birthday2026EconomyErrorReason, string> = {
+  config_not_found: "Event urodzinowy nie jest jeszcze skonfigurowany.",
+  currency_conflict: "Nazwa albo symbol waluty są już używane na tym serwerze.",
+  economy_already_configured: "Ekonomia jest już skonfigurowana z innymi wartościami.",
+  economy_not_configured: "Najpierw skonfiguruj ekonomię eventu.",
+  insufficient_balance: "Użytkownik nie ma wystarczającej ilości Paszy.",
+  invalid_amount: "Ilość musi być dodatnią liczbą całkowitą.",
+  invalid_currency: "Nazwa i symbol waluty nie mogą być puste.",
+  invalid_digestion_delay: "Czas trawienia musi być nieujemną liczbą sekund.",
+  invalid_source_key: "Klucz źródła nie może być pusty.",
+  member_not_found: "Ten użytkownik nie należy do eventu.",
+  team_wallet_not_found: "Drużyna nie ma poprawnie skonfigurowanego portfela.",
+};
+
+const replyWithEconomyError = (
+  itx: Parameters<typeof errorFollowUp>[0],
+  reason: Birthday2026EconomyErrorReason,
+) => errorFollowUp(itx, economyErrorMessages[reason]);
 
 const findTeamByRole = async (
   prisma: Parameters<typeof findBirthday2026Teams>[0],
@@ -200,6 +231,159 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
             });
             await itx.editReply({
               content: `Flagi zapisane: widoczny=${config.visible}, aktywny=${config.enabled}.`,
+            });
+          }),
+      )
+      .addCommand("ekonomia", (command) =>
+        command
+          .setDescription("Skonfiguruj walutę i czas trawienia")
+          .addString("nazwa", (option) =>
+            option.setDescription("Nazwa waluty eventowej"),
+          )
+          .addString("symbol", (option) =>
+            option.setDescription("Symbol waluty eventowej"),
+          )
+          .addInteger("trawienie-sekundy", (option) =>
+            option.setDescription("Czas trawienia w sekundach").setMinValue(0),
+          )
+          .handle(
+            async (
+              { prisma },
+              {
+                nazwa: currencyName,
+                symbol: currencySymbol,
+                "trawienie-sekundy": digestionDelaySeconds,
+              },
+              itx,
+            ) => {
+              if (!itx.inCachedGuild()) return;
+              await itx.deferReply({ flags: "Ephemeral" });
+              await ensureUserExists(prisma, itx.user);
+
+              const result = await setupBirthday2026Economy(prisma, {
+                guildId: itx.guildId,
+                currencyName,
+                currencySymbol,
+                digestionDelaySeconds,
+                createdByUserId: itx.user.id,
+              });
+              if (!result.ok) {
+                await replyWithEconomyError(itx, result.reason);
+                return;
+              }
+
+              await itx.editReply(
+                `Ekonomia skonfigurowana: waluta ${result.currencyId}, portfele drużyn: ${result.teamWalletCount}.`,
+              );
+            },
+          ),
+      ),
+  )
+  .group("urodziny-ops", (group) =>
+    group
+      .setDescription("Bieżąca obsługa eventu urodzinowego 2026")
+      .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers)
+      .setDMPermission(false)
+      .addCommand("daj-pasze", (command) =>
+        command
+          .setDescription("Przyznaj uczestnikowi audytowaną Paszę")
+          .addUser("user", (option) => option.setDescription("Uczestnik eventu"))
+          .addInteger("ilosc", (option) =>
+            option.setDescription("Ilość Paszy").setMinValue(1),
+          )
+          .addString("powod", (option) =>
+            option.setDescription("Powód przyznania Paszy"),
+          )
+          .handle(async ({ prisma }, { user, ilosc: amount, powod: reason }, itx) => {
+            if (!itx.inCachedGuild()) return;
+            await itx.deferReply({ flags: "Ephemeral" });
+            await ensureUserExists(prisma, itx.user);
+
+            const result = await grantBirthday2026Pasza(prisma, {
+              guildId: itx.guildId,
+              userId: user.id,
+              amount,
+              sourceKey: itx.id,
+              createdByUserId: itx.user.id,
+              reason,
+            });
+            if (!result.ok) {
+              await replyWithEconomyError(itx, result.reason);
+              return;
+            }
+
+            await itx.editReply(
+              `${result.created ? "Przyznano" : "To przyznanie było już zapisane:"} ${result.amount} Paszy dla ${userMention(result.userId)}. Saldo: ${result.walletBalance}.`,
+            );
+          }),
+      )
+      .addCommand("nakarm-test", (command) =>
+        command
+          .setDescription("Przetestuj karmienie świni uczestnika")
+          .addUser("user", (option) => option.setDescription("Uczestnik eventu"))
+          .addInteger("ilosc", (option) =>
+            option.setDescription("Ilość Paszy").setMinValue(1),
+          )
+          .addString("powod", (option) =>
+            option.setDescription("Powód testowego karmienia"),
+          )
+          .handle(
+            async (
+              { prisma, messageQueue },
+              { user, ilosc: amount, powod: reason },
+              itx,
+            ) => {
+              if (!itx.inCachedGuild()) return;
+              await itx.deferReply({ flags: "Ephemeral" });
+
+              const result = await feedBirthday2026Pig(prisma, {
+                guildId: itx.guildId,
+                userId: user.id,
+                amount,
+                sourceKey: itx.id,
+                acceptedAt: itx.createdAt,
+                reason,
+                scheduleDigestion: (tx, batch) =>
+                  messageQueue.push(
+                    "birthday2026Digest",
+                    { batchId: batch.id },
+                    batch.digestAt,
+                    batch.id.toString(),
+                    tx,
+                  ),
+              });
+              if (!result.ok) {
+                await replyWithEconomyError(itx, result.reason);
+                return;
+              }
+
+              await itx.editReply(
+                `${result.created ? "Nakarmiono" : "To karmienie było już zapisane:"} ${result.batch.amount} Paszy. Saldo osoby: ${result.personalBalance}, w korycie: ${result.teamBalance}, trawienie ${time(result.batch.digestAt, TimestampStyles.RelativeTime)}.`,
+              );
+            },
+          ),
+      )
+      .addCommand("status-ekonomii", (command) =>
+        command
+          .setDescription("Sprawdź wagę, koryta i spójność feed batchy")
+          .handle(async ({ prisma }, _, itx) => {
+            if (!itx.inCachedGuild()) return;
+            await itx.deferReply({ flags: "Ephemeral" });
+
+            const statuses = await getBirthday2026EconomyStatus(prisma, itx.guildId);
+            if (!statuses) {
+              await errorFollowUp(itx, "Ekonomia eventu nie jest skonfigurowana.");
+              return;
+            }
+
+            await itx.editReply({
+              content:
+                statuses
+                  .map(
+                    (status) =>
+                      `${bold(status.teamName)}: waga=${status.permanentWeight ?? "brak"}, koryto=${status.balance ?? "brak"}, batch=${status.unresolvedFeed ?? "brak"}, spójne=${status.reconciled ? "tak" : "NIE"}`,
+                  )
+                  .join("\n") || "Brak drużyn.",
             });
           }),
       )

--- a/apps/bot/src/events/birthday2026/teamService.ts
+++ b/apps/bot/src/events/birthday2026/teamService.ts
@@ -171,7 +171,10 @@ export const createBirthday2026Team = async (
 ) => {
   const config = await prisma.birthday2026Config.findUnique({
     where: { guildId: input.guildId },
-    select: { id: true },
+    select: {
+      id: true,
+      economy: { select: { currencyId: true } },
+    },
   });
   if (!config) return { ok: false, reason: "config_not_found" } as const;
 
@@ -187,6 +190,17 @@ export const createBirthday2026Team = async (
             name: input.name,
           },
         },
+        ...(config.economy
+          ? {
+              wallet: {
+                create: {
+                  currencyId: config.economy.currencyId,
+                  balance: 0,
+                  permanentWeight: 0,
+                },
+              },
+            }
+          : {}),
       },
       include: { team: true },
     });

--- a/apps/bot/src/messageQueueBase.ts
+++ b/apps/bot/src/messageQueueBase.ts
@@ -19,6 +19,7 @@ import {
 } from "discord.js";
 import { Effect } from "effect";
 import { database } from "./db";
+import { digestBirthday2026FeedBatch } from "./events/birthday2026/economyService";
 import { sendCombatlog } from "./events/halloween2025/combatLogUtil";
 import {
   PrismaCombatRepository,
@@ -90,6 +91,10 @@ type ModeratorLeaveEndData = {
 };
 type Halloween2025EndSpawnData = {
   spawnId: number;
+};
+
+type Birthday2026DigestData = {
+  batchId: number;
 };
 
 export const messageQueueBase = new Hashira({ name: "messageQueueBase" })
@@ -471,6 +476,21 @@ export const messageQueueBase = new Hashira({ name: "messageQueueBase" })
               member.user,
               "Hej, właśnie skończył się Twój urlop!",
             );
+          },
+        )
+        .addHandler(
+          "birthday2026Digest",
+          async (_, { batchId }: Birthday2026DigestData) => {
+            const result = await digestBirthday2026FeedBatch(prisma, {
+              batchId,
+              processedAt: new Date(),
+              reason: `Birthday 2026 digestion for feed batch ${batchId}`,
+            });
+            if (!result.ok && result.reason !== "batch_not_found") {
+              throw new Error(
+                `Failed to digest Birthday 2026 feed batch ${batchId}: ${result.reason}`,
+              );
+            }
           },
         )
         .addHandler(

--- a/apps/bot/test/birthday2026/economyService.database.test.ts
+++ b/apps/bot/test/birthday2026/economyService.database.test.ts
@@ -1,6 +1,5 @@
 import { afterAll, describe, expect, it } from "bun:test";
-import type { PrismaTransaction } from "@hashira/db";
-import { PrismaClient } from "@hashira/prisma-client";
+import { PrismaClient, type PrismaTransaction } from "@hashira/db";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { upsertBirthday2026Config } from "../../src/events/birthday2026/configService";
 import {

--- a/apps/bot/test/birthday2026/economyService.database.test.ts
+++ b/apps/bot/test/birthday2026/economyService.database.test.ts
@@ -1,0 +1,362 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import type { PrismaTransaction } from "@hashira/db";
+import { PrismaClient } from "@hashira/prisma-client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { upsertBirthday2026Config } from "../../src/events/birthday2026/configService";
+import {
+  digestBirthday2026FeedBatch,
+  feedBirthday2026Pig,
+  getBirthday2026EconomyStatus,
+  grantBirthday2026Pasza,
+  setupBirthday2026Economy,
+} from "../../src/events/birthday2026/economyService";
+import {
+  assignBirthday2026Member,
+  createBirthday2026Team,
+} from "../../src/events/birthday2026/teamService";
+
+const connectionString = process.env.DATABASE_TEST_URL;
+const databaseTests = describe.skipIf(!connectionString);
+const prisma = connectionString
+  ? new PrismaClient({
+      adapter: new PrismaPg({ connectionString }),
+    })
+  : null;
+
+const guildIds: string[] = [];
+const userIds: string[] = [];
+const currencyIds: number[] = [];
+const taskIds: number[] = [];
+
+const createFixture = async (digestionDelaySeconds: number) => {
+  if (!prisma) throw new Error("DATABASE_TEST_URL is required");
+  const suffix = crypto.randomUUID();
+  const guildId = `birthday-economy-guild-${suffix}`;
+  const actorUserId = `birthday-economy-actor-${suffix}`;
+  const memberUserId = `birthday-economy-member-${suffix}`;
+  guildIds.push(guildId);
+  userIds.push(actorUserId, memberUserId);
+
+  await prisma.guild.create({ data: { id: guildId } });
+  await prisma.user.createMany({
+    data: [{ id: actorUserId }, { id: memberUserId }],
+  });
+
+  const configResult = await upsertBirthday2026Config(prisma, {
+    guildId,
+    eventStartAt: new Date("2026-08-01T18:00:00Z"),
+    eventEndAt: new Date("2026-08-08T18:00:00Z"),
+    timezone: "Europe/Warsaw",
+    visible: false,
+    enabled: false,
+  });
+  if (!configResult.ok) throw new Error(configResult.reason);
+
+  const teamResult = await createBirthday2026Team(prisma, {
+    guildId,
+    name: `Team ${suffix}`,
+    roleId: `role-${suffix}`,
+    color: 0xff8800,
+  });
+  if (!teamResult.ok) throw new Error(teamResult.reason);
+
+  const assignment = await assignBirthday2026Member(prisma, {
+    guildId,
+    teamConfigId: teamResult.team.id,
+    userId: memberUserId,
+  });
+  if (!assignment.ok) throw new Error(assignment.reason);
+
+  const setup = await setupBirthday2026Economy(prisma, {
+    guildId,
+    currencyName: `Pasza ${suffix}`,
+    currencySymbol: `P${suffix.slice(0, 6)}`,
+    digestionDelaySeconds,
+    createdByUserId: actorUserId,
+  });
+  if (!setup.ok) throw new Error(setup.reason);
+  currencyIds.push(setup.currencyId);
+
+  return {
+    actorUserId,
+    config: configResult.config,
+    currencyId: setup.currencyId,
+    guildId,
+    memberUserId,
+    suffix,
+    team: teamResult.team,
+  };
+};
+
+const scheduleDigestion = async (
+  tx: PrismaTransaction,
+  batch: { id: number; digestAt: Date },
+) => {
+  const task = await tx.task.create({
+    data: {
+      identifier: batch.id.toString(),
+      handleAfter: batch.digestAt,
+      data: {
+        type: "birthday2026Digest",
+        data: { batchId: batch.id },
+      },
+    },
+  });
+  taskIds.push(task.id);
+};
+
+databaseTests("Birthday 2026 economy services", () => {
+  afterAll(async () => {
+    if (!prisma) return;
+
+    await prisma.task.deleteMany({ where: { id: { in: taskIds } } });
+    await prisma.birthday2026TeamWalletTransaction.deleteMany({
+      where: {
+        wallet: {
+          teamConfig: {
+            config: { guildId: { in: guildIds } },
+          },
+        },
+      },
+    });
+    await prisma.birthday2026Config.deleteMany({
+      where: { guildId: { in: guildIds } },
+    });
+    await prisma.transaction.deleteMany({
+      where: { wallet: { currencyId: { in: currencyIds } } },
+    });
+    await prisma.wallet.deleteMany({
+      where: { currencyId: { in: currencyIds } },
+    });
+    await prisma.currency.deleteMany({ where: { id: { in: currencyIds } } });
+    await prisma.team.deleteMany({ where: { guildId: { in: guildIds } } });
+    await prisma.guild.deleteMany({ where: { id: { in: guildIds } } });
+    await prisma.user.deleteMany({ where: { id: { in: userIds } } });
+    await prisma.$disconnect();
+  });
+
+  it("sets up explicit economy values and provisions wallets for later teams", async () => {
+    if (!prisma) throw new Error("DATABASE_TEST_URL is required");
+    const fixture = await createFixture(60);
+
+    const repeatedSetup = await setupBirthday2026Economy(prisma, {
+      guildId: fixture.guildId,
+      currencyName: `Pasza ${fixture.suffix}`,
+      currencySymbol: `P${fixture.suffix.slice(0, 6)}`,
+      digestionDelaySeconds: 60,
+      createdByUserId: fixture.actorUserId,
+    });
+    expect(repeatedSetup.ok).toBe(true);
+    expect(
+      await prisma.birthday2026EconomyConfig.findUnique({
+        where: { configId: fixture.config.id },
+      }),
+    ).toMatchObject({
+      currencyId: fixture.currencyId,
+      digestionDelaySeconds: 60,
+    });
+
+    const laterTeam = await createBirthday2026Team(prisma, {
+      guildId: fixture.guildId,
+      name: `Later ${fixture.suffix}`,
+      roleId: `later-role-${fixture.suffix}`,
+      color: 0x0088ff,
+    });
+    if (!laterTeam.ok) throw new Error(laterTeam.reason);
+
+    const wallet = await prisma.birthday2026TeamWallet.findUnique({
+      where: { teamConfigId: laterTeam.team.id },
+    });
+    expect(wallet).toMatchObject({
+      balance: 0,
+      currencyId: fixture.currencyId,
+      permanentWeight: 0,
+    });
+  });
+
+  it("grants, feeds, and digests exactly once while conserving Pasza", async () => {
+    if (!prisma) throw new Error("DATABASE_TEST_URL is required");
+    const fixture = await createFixture(60);
+
+    const grantInput = {
+      guildId: fixture.guildId,
+      userId: fixture.memberUserId,
+      amount: 100,
+      sourceKey: `grant-${fixture.suffix}`,
+      createdByUserId: fixture.actorUserId,
+      reason: "Slice 2 integration grant",
+    };
+    const grant = await grantBirthday2026Pasza(prisma, grantInput);
+    const repeatedGrant = await grantBirthday2026Pasza(prisma, grantInput);
+    expect(grant).toMatchObject({ ok: true, created: true, walletBalance: 100 });
+    expect(repeatedGrant).toMatchObject({
+      ok: true,
+      created: false,
+      walletBalance: 100,
+    });
+
+    const acceptedAt = new Date("2026-08-01T18:00:00Z");
+    const feedInput = {
+      guildId: fixture.guildId,
+      userId: fixture.memberUserId,
+      amount: 40,
+      sourceKey: `feed-${fixture.suffix}`,
+      acceptedAt,
+      reason: "Slice 2 integration feed",
+      scheduleDigestion,
+    };
+    const feed = await feedBirthday2026Pig(prisma, feedInput);
+    const repeatedFeed = await feedBirthday2026Pig(prisma, feedInput);
+    expect(feed).toMatchObject({
+      ok: true,
+      created: true,
+      personalBalance: 60,
+      teamBalance: 40,
+    });
+    expect(repeatedFeed).toMatchObject({
+      ok: true,
+      created: false,
+      personalBalance: 60,
+      teamBalance: 40,
+    });
+    if (!feed.ok) throw new Error(feed.reason);
+
+    const pendingStatus = await getBirthday2026EconomyStatus(prisma, fixture.guildId);
+    expect(pendingStatus?.[0]).toMatchObject({
+      balance: 40,
+      unresolvedFeed: 40,
+      permanentWeight: 0,
+      reconciled: true,
+    });
+    expect(
+      await prisma.task.count({
+        where: {
+          identifier: feed.batch.id.toString(),
+          data: { path: ["type"], equals: "birthday2026Digest" },
+        },
+      }),
+    ).toBe(1);
+
+    const digestionInput = {
+      batchId: feed.batch.id,
+      processedAt: feed.batch.digestAt,
+      reason: "Slice 2 integration digestion",
+    };
+    if (!connectionString) throw new Error("DATABASE_TEST_URL is required");
+    const restartedPrisma = new PrismaClient({
+      adapter: new PrismaPg({ connectionString }),
+    });
+    const digestion = await digestBirthday2026FeedBatch(
+      restartedPrisma,
+      digestionInput,
+    );
+    await restartedPrisma.$disconnect();
+    expect(digestion).toMatchObject({
+      ok: true,
+      digested: true,
+      amount: 40,
+      permanentWeight: 40,
+      teamBalance: 0,
+    });
+    expect(await digestBirthday2026FeedBatch(prisma, digestionInput)).toMatchObject({
+      ok: true,
+      digested: false,
+      permanentWeight: 40,
+      teamBalance: 0,
+    });
+
+    const finalStatus = await getBirthday2026EconomyStatus(prisma, fixture.guildId);
+    expect(finalStatus?.[0]).toMatchObject({
+      balance: 0,
+      unresolvedFeed: 0,
+      permanentWeight: 40,
+      reconciled: true,
+    });
+
+    const personalWallet = await prisma.wallet.findFirstOrThrow({
+      where: {
+        userId: fixture.memberUserId,
+        currencyId: fixture.currencyId,
+      },
+    });
+    expect(
+      personalWallet.balance +
+        (finalStatus?.[0]?.balance ?? 0) +
+        (finalStatus?.[0]?.permanentWeight ?? 0),
+    ).toBe(100);
+    expect(
+      await prisma.birthday2026TeamWalletTransaction.findMany({
+        where: { feedBatchId: feed.batch.id },
+        orderBy: { id: "asc" },
+        select: { source: true },
+      }),
+    ).toEqual([{ source: "feed" }, { source: "digestion" }]);
+  });
+
+  it("prevents concurrent feeds from overspending", async () => {
+    if (!prisma) throw new Error("DATABASE_TEST_URL is required");
+    const fixture = await createFixture(60);
+
+    const grant = await grantBirthday2026Pasza(prisma, {
+      guildId: fixture.guildId,
+      userId: fixture.memberUserId,
+      amount: 100,
+      sourceKey: `grant-${fixture.suffix}`,
+      createdByUserId: fixture.actorUserId,
+      reason: "Concurrency grant",
+    });
+    if (!grant.ok) throw new Error(grant.reason);
+
+    const results = await Promise.all(
+      ["a", "b"].map((key) =>
+        feedBirthday2026Pig(prisma, {
+          guildId: fixture.guildId,
+          userId: fixture.memberUserId,
+          amount: 70,
+          sourceKey: `feed-${key}-${fixture.suffix}`,
+          acceptedAt: new Date("2026-08-01T18:00:00Z"),
+          reason: `Concurrency feed ${key}`,
+          scheduleDigestion,
+        }),
+      ),
+    );
+    expect(results.filter((result) => result.ok)).toHaveLength(1);
+    expect(
+      results.filter(
+        (result) => !result.ok && result.reason === "insufficient_balance",
+      ),
+    ).toHaveLength(1);
+
+    const wallet = await prisma.wallet.findFirstOrThrow({
+      where: {
+        userId: fixture.memberUserId,
+        currencyId: fixture.currencyId,
+      },
+    });
+    const status = await getBirthday2026EconomyStatus(prisma, fixture.guildId);
+    expect(wallet.balance).toBe(30);
+    expect(status?.[0]).toMatchObject({
+      balance: 70,
+      unresolvedFeed: 70,
+      permanentWeight: 0,
+      reconciled: true,
+    });
+    expect(
+      await prisma.birthday2026FeedBatch.count({
+        where: { configId: fixture.config.id },
+      }),
+    ).toBe(1);
+    const batches = await prisma.birthday2026FeedBatch.findMany({
+      where: { configId: fixture.config.id },
+      select: { id: true },
+    });
+    expect(
+      await prisma.task.count({
+        where: {
+          data: { path: ["type"], equals: "birthday2026Digest" },
+          identifier: { in: batches.map((batch) => batch.id.toString()) },
+        },
+      }),
+    ).toBe(1);
+  });
+});

--- a/apps/bot/test/birthday2026/eventState.test.ts
+++ b/apps/bot/test/birthday2026/eventState.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "bun:test";
+import type { Birthday2026Config } from "@hashira/db";
 import {
   getBirthday2026EventDayIndex,
   getBirthday2026EventState,
@@ -8,11 +9,16 @@ import {
 const start = new Date("2026-08-01T18:00:00Z");
 const end = new Date("2026-08-08T18:00:00Z");
 
-const config = {
+const config: Birthday2026Config = {
+  id: 1,
+  guildId: "guild-id",
   enabled: true,
   eventStartAt: start,
   eventEndAt: end,
+  timezone: "UTC",
   visible: true,
+  createdAt: start,
+  updatedAt: start,
 };
 
 describe("Birthday 2026 event state", () => {

--- a/packages/db/prisma/migrations/20260723233441_add_birthday_2026_pasza_path/migration.sql
+++ b/packages/db/prisma/migrations/20260723233441_add_birthday_2026_pasza_path/migration.sql
@@ -1,0 +1,161 @@
+-- CreateEnum
+CREATE TYPE "Birthday2026PersonalTransactionSource" AS ENUM ('staffGrant', 'feed');
+
+-- CreateEnum
+CREATE TYPE "Birthday2026TeamWalletTransactionSource" AS ENUM ('feed', 'digestion');
+
+-- CreateTable
+CREATE TABLE "Birthday2026EconomyConfig" (
+    "configId" INTEGER NOT NULL,
+    "currencyId" INTEGER NOT NULL,
+    "digestionDelaySeconds" INTEGER NOT NULL,
+
+    CONSTRAINT "Birthday2026EconomyConfig_pkey" PRIMARY KEY ("configId")
+);
+
+-- CreateTable
+CREATE TABLE "Birthday2026TeamWallet" (
+    "id" SERIAL NOT NULL,
+    "teamConfigId" INTEGER NOT NULL,
+    "currencyId" INTEGER NOT NULL,
+    "balance" INTEGER NOT NULL,
+    "permanentWeight" INTEGER NOT NULL,
+    "createdAt" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(6) NOT NULL,
+
+    CONSTRAINT "Birthday2026TeamWallet_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Birthday2026TeamWalletTransaction" (
+    "id" SERIAL NOT NULL,
+    "walletId" INTEGER NOT NULL,
+    "feedBatchId" INTEGER NOT NULL,
+    "personalTransactionId" INTEGER,
+    "source" "Birthday2026TeamWalletTransactionSource" NOT NULL,
+    "entryType" "entry_type" NOT NULL,
+    "amount" INTEGER NOT NULL,
+    "reason" TEXT NOT NULL,
+    "sourceKey" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Birthday2026TeamWalletTransaction_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Birthday2026FeedBatch" (
+    "id" SERIAL NOT NULL,
+    "configId" INTEGER NOT NULL,
+    "walletId" INTEGER NOT NULL,
+    "userId" TEXT NOT NULL,
+    "personalTransactionId" INTEGER NOT NULL,
+    "amount" INTEGER NOT NULL,
+    "remainingAmount" INTEGER NOT NULL,
+    "sourceKey" TEXT NOT NULL,
+    "digestAt" TIMESTAMP(6) NOT NULL,
+    "digestedAt" TIMESTAMP(6),
+    "createdAt" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Birthday2026FeedBatch_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Birthday2026PersonalTransaction" (
+    "id" SERIAL NOT NULL,
+    "configId" INTEGER NOT NULL,
+    "userId" TEXT NOT NULL,
+    "transactionId" INTEGER NOT NULL,
+    "source" "Birthday2026PersonalTransactionSource" NOT NULL,
+    "sourceKey" TEXT NOT NULL,
+    "createdByUserId" TEXT,
+    "createdAt" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "Birthday2026PersonalTransaction_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Birthday2026EconomyConfig_currencyId_key" ON "Birthday2026EconomyConfig"("currencyId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Birthday2026TeamWallet_teamConfigId_key" ON "Birthday2026TeamWallet"("teamConfigId");
+
+-- CreateIndex
+CREATE INDEX "Birthday2026TeamWallet_currencyId_idx" ON "Birthday2026TeamWallet"("currencyId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Birthday2026TeamWalletTransaction_personalTransactionId_key" ON "Birthday2026TeamWalletTransaction"("personalTransactionId");
+
+-- CreateIndex
+CREATE INDEX "Birthday2026TeamWalletTransaction_feedBatchId_idx" ON "Birthday2026TeamWalletTransaction"("feedBatchId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Birthday2026TeamWalletTransaction_walletId_source_sourceKey_key" ON "Birthday2026TeamWalletTransaction"("walletId", "source", "sourceKey");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Birthday2026FeedBatch_personalTransactionId_key" ON "Birthday2026FeedBatch"("personalTransactionId");
+
+-- CreateIndex
+CREATE INDEX "Birthday2026FeedBatch_walletId_digestedAt_digestAt_idx" ON "Birthday2026FeedBatch"("walletId", "digestedAt", "digestAt");
+
+-- CreateIndex
+CREATE INDEX "Birthday2026FeedBatch_userId_idx" ON "Birthday2026FeedBatch"("userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Birthday2026FeedBatch_configId_sourceKey_key" ON "Birthday2026FeedBatch"("configId", "sourceKey");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Birthday2026PersonalTransaction_transactionId_key" ON "Birthday2026PersonalTransaction"("transactionId");
+
+-- CreateIndex
+CREATE INDEX "Birthday2026PersonalTransaction_userId_idx" ON "Birthday2026PersonalTransaction"("userId");
+
+-- CreateIndex
+CREATE INDEX "Birthday2026PersonalTransaction_createdByUserId_idx" ON "Birthday2026PersonalTransaction"("createdByUserId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Birthday2026PersonalTransaction_configId_source_sourceKey_key" ON "Birthday2026PersonalTransaction"("configId", "source", "sourceKey");
+
+-- AddForeignKey
+ALTER TABLE "Birthday2026EconomyConfig" ADD CONSTRAINT "Birthday2026EconomyConfig_configId_fkey" FOREIGN KEY ("configId") REFERENCES "Birthday2026Config"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Birthday2026EconomyConfig" ADD CONSTRAINT "Birthday2026EconomyConfig_currencyId_fkey" FOREIGN KEY ("currencyId") REFERENCES "currency"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Birthday2026TeamWallet" ADD CONSTRAINT "Birthday2026TeamWallet_teamConfigId_fkey" FOREIGN KEY ("teamConfigId") REFERENCES "Birthday2026TeamConfig"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Birthday2026TeamWallet" ADD CONSTRAINT "Birthday2026TeamWallet_currencyId_fkey" FOREIGN KEY ("currencyId") REFERENCES "currency"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Birthday2026TeamWalletTransaction" ADD CONSTRAINT "Birthday2026TeamWalletTransaction_walletId_fkey" FOREIGN KEY ("walletId") REFERENCES "Birthday2026TeamWallet"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Birthday2026TeamWalletTransaction" ADD CONSTRAINT "Birthday2026TeamWalletTransaction_feedBatchId_fkey" FOREIGN KEY ("feedBatchId") REFERENCES "Birthday2026FeedBatch"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Birthday2026TeamWalletTransaction" ADD CONSTRAINT "Birthday2026TeamWalletTransaction_personalTransactionId_fkey" FOREIGN KEY ("personalTransactionId") REFERENCES "transaction"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Birthday2026FeedBatch" ADD CONSTRAINT "Birthday2026FeedBatch_configId_fkey" FOREIGN KEY ("configId") REFERENCES "Birthday2026Config"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Birthday2026FeedBatch" ADD CONSTRAINT "Birthday2026FeedBatch_walletId_fkey" FOREIGN KEY ("walletId") REFERENCES "Birthday2026TeamWallet"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Birthday2026FeedBatch" ADD CONSTRAINT "Birthday2026FeedBatch_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Birthday2026FeedBatch" ADD CONSTRAINT "Birthday2026FeedBatch_personalTransactionId_fkey" FOREIGN KEY ("personalTransactionId") REFERENCES "transaction"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Birthday2026PersonalTransaction" ADD CONSTRAINT "Birthday2026PersonalTransaction_configId_fkey" FOREIGN KEY ("configId") REFERENCES "Birthday2026Config"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Birthday2026PersonalTransaction" ADD CONSTRAINT "Birthday2026PersonalTransaction_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Birthday2026PersonalTransaction" ADD CONSTRAINT "Birthday2026PersonalTransaction_createdByUserId_fkey" FOREIGN KEY ("createdByUserId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Birthday2026PersonalTransaction" ADD CONSTRAINT "Birthday2026PersonalTransaction_transactionId_fkey" FOREIGN KEY ("transactionId") REFERENCES "transaction"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/db/prisma/migrations/20260723233442_add_birthday_2026_pasza_checks/migration.sql
+++ b/packages/db/prisma/migrations/20260723233442_add_birthday_2026_pasza_checks/migration.sql
@@ -1,0 +1,49 @@
+-- Manual migration based on 20260723233441_add_birthday_2026_pasza_path.
+
+ALTER TABLE "Birthday2026EconomyConfig"
+  ADD CONSTRAINT "Birthday2026EconomyConfig_digestion_delay_valid"
+  CHECK ("digestionDelaySeconds" >= 0);
+
+ALTER TABLE "Birthday2026TeamWallet"
+  ADD CONSTRAINT "Birthday2026TeamWallet_balance_valid"
+  CHECK ("balance" >= 0),
+  ADD CONSTRAINT "Birthday2026TeamWallet_permanent_weight_valid"
+  CHECK ("permanentWeight" >= 0);
+
+ALTER TABLE "Birthday2026TeamWalletTransaction"
+  ADD CONSTRAINT "Birthday2026TeamWalletTransaction_amount_valid"
+  CHECK ("amount" > 0),
+  ADD CONSTRAINT "Birthday2026TeamWalletTransaction_source_key_nonempty"
+  CHECK (length(trim("sourceKey")) > 0),
+  ADD CONSTRAINT "Birthday2026TeamWalletTransaction_source_shape_valid"
+  CHECK (
+    (
+      "source" = 'feed'
+      AND "entryType" = 'credit'
+      AND "personalTransactionId" IS NOT NULL
+    )
+    OR (
+      "source" = 'digestion'
+      AND "entryType" = 'debit'
+      AND "personalTransactionId" IS NULL
+    )
+  );
+
+ALTER TABLE "Birthday2026FeedBatch"
+  ADD CONSTRAINT "Birthday2026FeedBatch_amount_valid"
+  CHECK ("amount" > 0),
+  ADD CONSTRAINT "Birthday2026FeedBatch_remaining_amount_valid"
+  CHECK ("remainingAmount" BETWEEN 0 AND "amount"),
+  ADD CONSTRAINT "Birthday2026FeedBatch_digested_state_valid"
+  CHECK ("digestedAt" IS NULL OR "remainingAmount" = 0),
+  ADD CONSTRAINT "Birthday2026FeedBatch_source_key_nonempty"
+  CHECK (length(trim("sourceKey")) > 0);
+
+ALTER TABLE "Birthday2026PersonalTransaction"
+  ADD CONSTRAINT "Birthday2026PersonalTransaction_source_key_nonempty"
+  CHECK (length(trim("sourceKey")) > 0),
+  ADD CONSTRAINT "Birthday2026PersonalTransaction_creator_valid"
+  CHECK (
+    ("source" = 'staffGrant' AND "createdByUserId" IS NOT NULL)
+    OR ("source" <> 'staffGrant' AND "createdByUserId" IS NULL)
+  );

--- a/packages/db/prisma/models/birthday2026.prisma
+++ b/packages/db/prisma/models/birthday2026.prisma
@@ -9,8 +9,20 @@ model Birthday2026Config {
   createdAt           DateTime @default(now()) @db.Timestamp(6)
   updatedAt           DateTime @updatedAt @db.Timestamp(6)
 
-  guild Guild                    @relation(fields: [guildId], references: [id], onDelete: Cascade)
-  teams Birthday2026TeamConfig[]
+  guild                Guild                             @relation(fields: [guildId], references: [id], onDelete: Cascade)
+  economy              Birthday2026EconomyConfig?
+  teams                Birthday2026TeamConfig[]
+  feedBatches          Birthday2026FeedBatch[]
+  personalTransactions Birthday2026PersonalTransaction[]
+}
+
+model Birthday2026EconomyConfig {
+  configId               Int @id
+  currencyId             Int @unique
+  digestionDelaySeconds  Int
+
+  config   Birthday2026Config @relation(fields: [configId], references: [id], onDelete: Cascade)
+  currency Currency           @relation(fields: [currencyId], references: [id], onDelete: Restrict)
 }
 
 model Birthday2026TeamConfig {
@@ -25,6 +37,7 @@ model Birthday2026TeamConfig {
   team         Team                      @relation(fields: [teamId], references: [id], onDelete: Cascade)
   captainUser  User?                     @relation("birthday2026Captain", fields: [captainUserId], references: [id])
   memberStates Birthday2026MemberState[]
+  wallet       Birthday2026TeamWallet?
 
   @@unique([id, configId])
   @@unique([configId, captainUserId])
@@ -43,4 +56,95 @@ model Birthday2026MemberState {
   @@unique([configId, userId])
   @@index([teamConfigId, configId])
   @@index([userId])
+}
+
+model Birthday2026TeamWallet {
+  id              Int      @id @default(autoincrement())
+  teamConfigId    Int      @unique
+  currencyId      Int
+  balance         Int
+  permanentWeight Int
+  createdAt       DateTime @default(now()) @db.Timestamp(6)
+  updatedAt       DateTime @updatedAt @db.Timestamp(6)
+
+  teamConfig   Birthday2026TeamConfig              @relation(fields: [teamConfigId], references: [id], onDelete: Cascade)
+  currency     Currency                            @relation(fields: [currencyId], references: [id], onDelete: Restrict)
+  transactions Birthday2026TeamWalletTransaction[]
+  feedBatches  Birthday2026FeedBatch[]
+
+  @@index([currencyId])
+}
+
+model Birthday2026TeamWalletTransaction {
+  id                    Int       @id @default(autoincrement())
+  walletId              Int
+  feedBatchId           Int
+  personalTransactionId Int?      @unique
+  source                Birthday2026TeamWalletTransactionSource
+  entryType             EntryType
+  amount                Int
+  reason                String
+  sourceKey             String
+  createdAt             DateTime  @default(now()) @db.Timestamp(6)
+
+  wallet              Birthday2026TeamWallet @relation(fields: [walletId], references: [id], onDelete: Cascade)
+  feedBatch           Birthday2026FeedBatch  @relation(fields: [feedBatchId], references: [id], onDelete: Restrict)
+  personalTransaction Transaction?           @relation(fields: [personalTransactionId], references: [id], onDelete: Restrict)
+
+  @@unique([walletId, source, sourceKey])
+  @@index([feedBatchId])
+}
+
+model Birthday2026FeedBatch {
+  id                    Int       @id @default(autoincrement())
+  configId              Int
+  walletId              Int
+  userId                String
+  personalTransactionId Int       @unique
+  amount                Int
+  remainingAmount       Int
+  sourceKey             String
+  digestAt              DateTime  @db.Timestamp(6)
+  digestedAt            DateTime? @db.Timestamp(6)
+  createdAt             DateTime  @default(now()) @db.Timestamp(6)
+
+  config              Birthday2026Config                  @relation(fields: [configId], references: [id], onDelete: Cascade)
+  wallet              Birthday2026TeamWallet              @relation(fields: [walletId], references: [id], onDelete: Cascade)
+  user                User                                @relation("birthday2026FeedOwner", fields: [userId], references: [id], onDelete: Cascade)
+  personalTransaction Transaction                         @relation(fields: [personalTransactionId], references: [id], onDelete: Restrict)
+  teamTransactions    Birthday2026TeamWalletTransaction[]
+
+  @@unique([configId, sourceKey])
+  @@index([walletId, digestedAt, digestAt])
+  @@index([userId])
+}
+
+enum Birthday2026PersonalTransactionSource {
+  staffGrant
+  feed
+}
+
+enum Birthday2026TeamWalletTransactionSource {
+  feed
+  digestion
+}
+
+model Birthday2026PersonalTransaction {
+  id              Int                                   @id @default(autoincrement())
+  configId        Int
+  userId          String
+  transactionId   Int                                   @unique
+  source          Birthday2026PersonalTransactionSource
+  sourceKey       String
+  createdByUserId String?
+  createdAt       DateTime                              @default(now()) @db.Timestamp(6)
+
+  config        Birthday2026Config @relation(fields: [configId], references: [id], onDelete: Cascade)
+  user          User               @relation("birthday2026PersonalTransactionOwner", fields: [userId], references: [id], onDelete: Cascade)
+  createdByUser User?              @relation("birthday2026PersonalTransactionCreator", fields: [createdByUserId], references: [id], onDelete: Restrict)
+  transaction   Transaction        @relation(fields: [transactionId], references: [id], onDelete: Restrict)
+
+  @@unique([configId, source, sourceKey])
+  @@index([userId])
+  @@index([createdByUserId])
 }

--- a/packages/db/prisma/models/economy.prisma
+++ b/packages/db/prisma/models/economy.prisma
@@ -6,10 +6,12 @@ model Currency {
   createdBy String
   createdAt DateTime @default(now()) @db.Timestamp(6)
 
-  user                             User       @relation(fields: [createdBy], references: [id], onDelete: SetNull, onUpdate: NoAction, map: "currency_createdBy_users_id_fk")
-  guild                            Guild      @relation(fields: [guildId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "currency_guildId_guild_id_fk")
-  wallet_wallet_currencyTocurrency Wallet[]   @relation("wallet_currencyTocurrency")
+  user                             User                     @relation(fields: [createdBy], references: [id], onDelete: SetNull, onUpdate: NoAction, map: "currency_createdBy_users_id_fk")
+  guild                            Guild                    @relation(fields: [guildId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "currency_guildId_guild_id_fk")
+  wallet_wallet_currencyTocurrency Wallet[]                 @relation("wallet_currencyTocurrency")
   shopItems                        ShopItem[]
+  birthday2026EconomyConfig        Birthday2026EconomyConfig?
+  birthday2026TeamWallets          Birthday2026TeamWallet[]
 
   @@unique([guildId, name], map: "currency_guildId_name_unique")
   @@unique([guildId, symbol], map: "currency_guildId_symbol_unique")
@@ -47,9 +49,12 @@ model Transaction {
   transactionType TransactionType
   entryType       EntryType
 
-  relatedUser   User?   @relation(fields: [relatedUserId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "transaction_relatedUserId_users_id_fk")
-  relatedWallet Wallet? @relation("transaction_relatedWalletTowallet", fields: [relatedWalletId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "transaction_relatedWallet_wallet_id_fk")
-  wallet        Wallet  @relation("transaction_walletTowallet", fields: [walletId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "transaction_wallet_wallet_id_fk")
+  relatedUser                       User?                              @relation(fields: [relatedUserId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "transaction_relatedUserId_users_id_fk")
+  relatedWallet                     Wallet?                            @relation("transaction_relatedWalletTowallet", fields: [relatedWalletId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "transaction_relatedWallet_wallet_id_fk")
+  wallet                            Wallet                             @relation("transaction_walletTowallet", fields: [walletId], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "transaction_wallet_wallet_id_fk")
+  birthday2026PersonalTransaction   Birthday2026PersonalTransaction?
+  birthday2026TeamWalletTransaction Birthday2026TeamWalletTransaction?
+  birthday2026FeedBatch             Birthday2026FeedBatch?
 
   @@map("transaction")
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -175,6 +175,9 @@ model User {
   easter2026CaptainOf               Easter2026TeamConfig[]             @relation("easter2026Captain")
   birthday2026CaptainOf             Birthday2026TeamConfig[]           @relation("birthday2026Captain")
   birthday2026MemberStates          Birthday2026MemberState[]
+  birthday2026FeedBatches           Birthday2026FeedBatch[]            @relation("birthday2026FeedOwner")
+  birthday2026PersonalTransactions  Birthday2026PersonalTransaction[]  @relation("birthday2026PersonalTransactionOwner")
+  createdBirthday2026Transactions   Birthday2026PersonalTransaction[]  @relation("birthday2026PersonalTransactionCreator")
 
   @@map("users")
 }


### PR DESCRIPTION
## Summary

- add the event-owned Pasza currency, team wallets, immutable ledger entries, and feed batches
- add audited idempotent staff grants and atomic test feeding
- add persistent restart-safe digestion and reconciliation status
- add concurrency, conservation, retry, and database integration coverage
- keep automatic earning and player-facing feeding out of this slice

## Why

This provides one complete Pasza-to-permanent-weight path that can be tested and merged independently before the broader playable event is implemented. Currency details and digestion timing remain explicit configuration rather than code defaults.

## Validation

- 21 Birthday 2026 tests passing
- bot and repository-wide typechecks
- Prisma format, validate, generate, and migration deployment

Depends on #274.