### PR TITLE
fix: temporarily disable unapproved privileged intents

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ BOT_CLIENT_ID=123456789012345678
 BOT_DEVELOPER_GUILD_IDS="123456789012345678 987654321098765432"
 
 # Optional settings
+# Keep false unless Discord has approved both Guild Members and Message Content.
+BOT_PRIVILEGED_INTENTS_ENABLED=false
 OPENAI_KEY="your-openai-key"
 SHLINK_API_KEY="your-shlink-api-key"
 SHLINK_API_URL="http://your-shlink-url"

--- a/apps/bot/src/ai.ts
+++ b/apps/bot/src/ai.ts
@@ -93,7 +93,10 @@ export const ai = new Hashira({ name: "ai" })
   .const("ai", env.OPENAI_KEY ? new OpenAI({ apiKey: env.OPENAI_KEY }) : null)
   .handle(
     "messageCreate",
-    async ({ ai, prisma, messageQueue, moderationLog }, message) => {
+    async (
+      { ai, prisma, messageQueue, moderationLog, privilegedIntentsEnabled },
+      message,
+    ) => {
       if (!ai) return;
       if (message.author.bot) return;
       if (!message.inGuild()) return;
@@ -108,13 +111,14 @@ export const ai = new Hashira({ name: "ai" })
       const thread = await message.startThread({ name: "AI Command" });
 
       const reference = message.reference;
-      const repliedMessage = reference?.messageId
-        ? await discordTry(
-            () => message.channel.messages.fetch(reference.messageId as string),
-            [RESTJSONErrorCodes.UnknownMessage],
-            () => null,
-          )
-        : null;
+      const repliedMessage =
+        privilegedIntentsEnabled && reference?.messageId
+          ? await discordTry(
+              () => message.channel.messages.fetch(reference.messageId as string),
+              [RESTJSONErrorCodes.UnknownMessage],
+              () => null,
+            )
+          : null;
 
       const prompt = [
         "You are Biszkopt, an advanced AI moderation assistant for a Discord server. You identify as male.",
@@ -289,7 +293,7 @@ export const ai = new Hashira({ name: "ai" })
             {
               type: "function",
               function: {
-                function: createFetchMessage(message.guild),
+                function: createFetchMessage(message.guild, privilegedIntentsEnabled),
                 description: "Fetch a message by its ID and channel ID.",
                 parse: JSON.parse,
                 parameters: {

--- a/apps/bot/src/ai/tools.ts
+++ b/apps/bot/src/ai/tools.ts
@@ -98,7 +98,7 @@ export const createGetLatestWarns = (prisma: ExtendedPrismaClient, guildId: stri
   };
 };
 
-export const createFetchMessage = (guild: Guild) => {
+export const createFetchMessage = (guild: Guild, enabled = true) => {
   return async function fetchMessage({
     channelId,
     messageId,
@@ -106,6 +106,10 @@ export const createFetchMessage = (guild: Guild) => {
     channelId: string;
     messageId: string;
   }) {
+    if (!enabled) {
+      return "Message fetching is temporarily unavailable.";
+    }
+
     const channel = await guild.channels.fetch(channelId);
     if (!channel || !channel.isTextBased()) {
       return "Channel not found or is not text-based.";

--- a/apps/bot/src/base.ts
+++ b/apps/bot/src/base.ts
@@ -16,6 +16,7 @@ export const base = new Hashira({ name: "base" })
   .use(messageQueueBase)
   .use(userActivityBase)
   .use(emojiCountingBase)
+  .const("privilegedIntentsEnabled", env.BOT_PRIVILEGED_INTENTS_ENABLED)
   .const("lock", new LockManager())
   .addExceptionHandler("default", (e, itx) => {
     if (env.SENTRY_DSN) {

--- a/apps/bot/src/dmVoting.ts
+++ b/apps/bot/src/dmVoting.ts
@@ -35,6 +35,7 @@ import { hastebin } from "./util/hastebin";
 import { numberToEmoji } from "./util/numberToEmoji";
 import { parseUserMentions } from "./util/parseUsers";
 import { pluralizers } from "./util/pluralize";
+import { PRIVILEGED_FEATURES_DISABLED_MESSAGE } from "./util/privilegedIntents";
 import { CannotSendMessagesToThisUserNoMutualGuids } from "./util/sendDirectMessage";
 
 type DMPollWithOptions = DmPoll & { options: DmPollOption[] };
@@ -485,7 +486,11 @@ export const dmVoting = new Hashira({ name: "dmVoting" })
           .addRole("rola", (role) =>
             role.setDescription("Rola, w której użytkownicy mogą głosować"),
           )
-          .handle(async ({ prisma }, { id, rola: role }, itx) => {
+          .handle(async (ctx, { id, rola: role }, itx) => {
+            if (!ctx.privilegedIntentsEnabled) {
+              return errorFollowUp(itx, PRIVILEGED_FEATURES_DISABLED_MESSAGE);
+            }
+            const { prisma } = ctx;
             if (!itx.inCachedGuild()) return;
 
             const poll = await prisma.dmPoll.findFirst({

--- a/apps/bot/src/emojiCounting/emojiCounting.ts
+++ b/apps/bot/src/emojiCounting/emojiCounting.ts
@@ -33,7 +33,8 @@ const parseEmojis = (guildEmojiManager: GuildEmojiManager, content: string) => {
 
 export const emojiCounting = new Hashira({ name: "emoji-counting" })
   .use(base)
-  .handle("guildMessageCreate", async ({ emojiCountingQueue }, message) => {
+  .handle("guildMessageCreate", async (ctx, message) => {
+    if (!ctx.privilegedIntentsEnabled) return;
     if (message.author.bot) return;
 
     const matches = message.content.matchAll(EMOJI_REGEX);
@@ -42,7 +43,7 @@ export const emojiCounting = new Hashira({ name: "emoji-counting" })
     const guildEmojis = parseEmojis(message.guild.emojis, message.content);
     if (guildEmojis.length === 0) return;
 
-    emojiCountingQueue.push(
+    ctx.emojiCountingQueue.push(
       message.channelId,
       guildEmojis.map((emoji) => ({
         userId: message.author.id,

--- a/apps/bot/src/guildAvailability.ts
+++ b/apps/bot/src/guildAvailability.ts
@@ -85,6 +85,8 @@ async function processAllowedGuild(ctx: BaseContext, guild: Guild) {
   await createGuildSettings(ctx.prisma, guild.id);
   await registerGuildLoggers(ctx, guild);
 
+  if (!ctx.privilegedIntentsEnabled) return;
+
   try {
     await guild.members.fetch();
   } catch (e) {

--- a/apps/bot/src/index.ts
+++ b/apps/bot/src/index.ts
@@ -2,6 +2,7 @@ import { Hashira } from "@hashira/core";
 import env from "@hashira/env";
 import { PrismaInstrumentation } from "@prisma/instrumentation";
 import * as Sentry from "@sentry/bun";
+import { GatewayIntentBits } from "discord.js";
 import { ai } from "./ai";
 import { autoRole } from "./autoRole";
 import { avatar } from "./avatar";
@@ -96,7 +97,11 @@ if (import.meta.main) {
         env.BOT_CLIENT_ID,
       );
     }
-    await bot.start(env.BOT_TOKEN);
+    await bot.start(env.BOT_TOKEN, {
+      disabledIntents: env.BOT_PRIVILEGED_INTENTS_ENABLED
+        ? []
+        : [GatewayIntentBits.GuildMembers, GatewayIntentBits.MessageContent],
+    });
   } catch (e) {
     if (env.SENTRY_DSN) Sentry.captureException(e);
     console.error(e);

--- a/apps/bot/src/logging/discordEventLogging.ts
+++ b/apps/bot/src/logging/discordEventLogging.ts
@@ -18,7 +18,9 @@ const warnMissingAuditLogEntryTarget = (entry: GuildAuditLogsEntry) => {
 // Logging for Discord events
 export const discordEventLogging = new Hashira({ name: "discordEventLogging" })
   .use(base)
-  .handle("messageDelete", async ({ messageLog: log }, message) => {
+  .handle("messageDelete", async (ctx, message) => {
+    if (!ctx.privilegedIntentsEnabled) return;
+    const log = ctx.messageLog;
     if (!message.inGuild()) return;
     if (!log.isRegistered(message.guild)) return;
     // NOTE: Deleting an uncached message can still trigger this event with unexpected
@@ -27,7 +29,9 @@ export const discordEventLogging = new Hashira({ name: "discordEventLogging" })
 
     log.push("messageDelete", message.guild, { message });
   })
-  .handle("messageUpdate", async ({ messageLog: log }, oldMessage, newMessage) => {
+  .handle("messageUpdate", async (ctx, oldMessage, newMessage) => {
+    if (!ctx.privilegedIntentsEnabled) return;
+    const log = ctx.messageLog;
     if (!oldMessage.inGuild() || !newMessage.inGuild()) return;
     if (!log.isRegistered(oldMessage.guild) || !log.isRegistered(newMessage.guild))
       return;

--- a/apps/bot/src/massDM.ts
+++ b/apps/bot/src/massDM.ts
@@ -5,6 +5,7 @@ import { base } from "./base";
 import { discordTry } from "./util/discordTry";
 import { errorFollowUp } from "./util/errorFollowUp";
 import { pluralizers } from "./util/pluralize";
+import { PRIVILEGED_FEATURES_DISABLED_MESSAGE } from "./util/privilegedIntents";
 import safeSendCode from "./util/safeSendCode";
 import { CannotSendMessagesToThisUserNoMutualGuids } from "./util/sendDirectMessage";
 
@@ -24,7 +25,11 @@ export const massDM = new Hashira({ name: "massDM" })
           .addString("tresc", (content) =>
             content.setDescription("Treść wiadomości").setRequired(true),
           )
-          .handle(async ({ strataCzasuLog }, { rola: role, tresc: content }, itx) => {
+          .handle(async (ctx, { rola: role, tresc: content }, itx) => {
+            if (!ctx.privilegedIntentsEnabled) {
+              return errorFollowUp(itx, PRIVILEGED_FEATURES_DISABLED_MESSAGE);
+            }
+            const { strataCzasuLog } = ctx;
             if (!itx.inCachedGuild()) return;
             await itx.deferReply();
 

--- a/apps/bot/src/miscellaneous.ts
+++ b/apps/bot/src/miscellaneous.ts
@@ -29,6 +29,7 @@ import { errorFollowUp } from "./util/errorFollowUp";
 import { fetchMembers } from "./util/fetchMembers";
 import { isNotOwner } from "./util/isOwner";
 import { parseUserMentions } from "./util/parseUsers";
+import { PRIVILEGED_FEATURES_DISABLED_MESSAGE } from "./util/privilegedIntents";
 
 export const miscellaneous = new Hashira({ name: "miscellaneous" })
   .use(base)
@@ -221,7 +222,10 @@ export const miscellaneous = new Hashira({ name: "miscellaneous" })
           .addString("message", (message) => message.setDescription("ID wiadomości"))
           .addRole("role", (role) => role.setDescription("Rola"))
           .addString("emoji", (emoji) => emoji.setDescription("Emoji"))
-          .handle(async (_, { message: messageId, role, emoji: emojiName }, itx) => {
+          .handle(async (ctx, { message: messageId, role, emoji: emojiName }, itx) => {
+            if (!ctx.privilegedIntentsEnabled) {
+              return errorFollowUp(itx, PRIVILEGED_FEATURES_DISABLED_MESSAGE);
+            }
             if (!itx.inCachedGuild()) return;
             await itx.deferReply();
 
@@ -281,14 +285,17 @@ export const miscellaneous = new Hashira({ name: "miscellaneous" })
           .setDescription("Add balance to role")
           .addRole("role", (role) => role.setDescription("Role"))
           .addInteger("amount", (amount) => amount.setDescription("Amount"))
-          .handle(async ({ prisma }, { role, amount }, itx) => {
+          .handle(async (ctx, { role, amount }, itx) => {
+            if (!ctx.privilegedIntentsEnabled) {
+              return errorFollowUp(itx, PRIVILEGED_FEATURES_DISABLED_MESSAGE);
+            }
             if (!itx.inCachedGuild()) return;
             await itx.deferReply();
 
             const members = [...role.members.keys()];
 
             await addBalances({
-              prisma,
+              prisma: ctx.prisma,
               fromUserId: itx.user.id,
               guildId: itx.guildId,
               toUserIds: members,
@@ -331,7 +338,10 @@ export const miscellaneous = new Hashira({ name: "miscellaneous" })
       .addCommand("count-guild-tags", (command) =>
         command
           .setDescription("Count most popular guild tags")
-          .handle(async (_, __, itx) => {
+          .handle(async ({ privilegedIntentsEnabled }, __, itx) => {
+            if (!privilegedIntentsEnabled) {
+              return errorFollowUp(itx, PRIVILEGED_FEATURES_DISABLED_MESSAGE);
+            }
             if (!itx.inCachedGuild()) return;
             await itx.deferReply();
 

--- a/apps/bot/src/strata/embedPermissions.ts
+++ b/apps/bot/src/strata/embedPermissions.ts
@@ -19,6 +19,7 @@ const getReminderKey = (userId: string, guildId: string) =>
 export const embedPermissions = new Hashira({ name: "embed-permissions" })
   .use(base)
   .handle("messageCreate", async (ctx, message) => {
+    if (!ctx.privilegedIntentsEnabled) return;
     if (message.author.bot || !message.inGuild()) return;
     if (message.embeds.length > 0 || message.attachments.size > 0) return;
 

--- a/apps/bot/src/strata/pearto.ts
+++ b/apps/bot/src/strata/pearto.ts
@@ -12,13 +12,14 @@ const resEmoji = "<a:peartotanczy:1410749447608205322>";
 export const pearto = new Hashira({ name: "pearto" })
   .use(base)
   .const("peartoCooldown", new Cooldown({ minutes: 1 }))
-  .handle("messageCreate", async ({ prisma, peartoCooldown }, message) => {
+  .handle("messageCreate", async (ctx, message) => {
+    if (!ctx.privilegedIntentsEnabled) return;
     if (
       message.channelId !== channelId ||
       message.author.bot ||
       !message.inGuild() ||
       message.content.trim() !== "🍐" ||
-      !peartoCooldown.ended(message.createdAt)
+      !ctx.peartoCooldown.ended(message.createdAt)
     )
       return;
 
@@ -26,7 +27,7 @@ export const pearto = new Hashira({ name: "pearto" })
     const startOfDayLocal = startOfDay(localDate);
     const startOfDayUTC = new Date(startOfDayLocal.getTime());
 
-    const todaysMessages = await prisma.userTextActivity.count({
+    const todaysMessages = await ctx.prisma.userTextActivity.count({
       where: {
         channelId,
         guildId,

--- a/apps/bot/src/util/privilegedIntents.ts
+++ b/apps/bot/src/util/privilegedIntents.ts
@@ -1,0 +1,2 @@
+export const PRIVILEGED_FEATURES_DISABLED_MESSAGE =
+  "Ta funkcja jest tymczasowo niedostępna, ponieważ bot działa bez uprzywilejowanych intentów Discorda.";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -5,6 +5,7 @@ import {
   type ChatInputCommandInteraction,
   Client,
   ContextMenuCommandBuilder,
+  type GatewayIntentBits,
   type Interaction,
   InteractionContextType,
   type MessageContextMenuCommandInteraction,
@@ -20,6 +21,7 @@ import {
 import { capitalize } from "es-toolkit";
 import { handleCustomEvent } from "./customEvents";
 import { allEventsToIntent, type EventMethodName, isCustomEvent } from "./intents";
+import { filterDisabledIntents } from "./intents/util";
 import { Group, TopLevelSlashCommand } from "./slashCommands";
 import type {
   BaseDecorator,
@@ -43,6 +45,10 @@ const commandsInitBase = {};
 
 type HashiraOptions = {
   name: string;
+};
+
+type HashiraStartOptions = {
+  disabledIntents?: readonly GatewayIntentBits[];
 };
 
 type HashiraSlashCommandOptions =
@@ -493,12 +499,15 @@ class Hashira<
     }
   }
 
-  async start(token: string) {
-    const intents = [
-      ...new Set(
-        [...this.#methods.keys()].flatMap((event) => allEventsToIntent[event]),
-      ),
-    ];
+  async start(token: string, options: HashiraStartOptions = {}) {
+    const intents = filterDisabledIntents(
+      [
+        ...new Set(
+          [...this.#methods.keys()].flatMap((event) => allEventsToIntent[event]),
+        ),
+      ],
+      options.disabledIntents ?? [],
+    );
 
     const discordClient = new Client({
       intents,

--- a/packages/core/src/intents/util.ts
+++ b/packages/core/src/intents/util.ts
@@ -21,3 +21,11 @@ export const createEventsToIntent = <
   Object.fromEntries(
     events.map((event) => [event, intents] as const),
   ) as EventsToIntents<Events, Intents>;
+
+export const filterDisabledIntents = (
+  intents: readonly GatewayIntentBits[],
+  disabledIntents: readonly GatewayIntentBits[],
+) => {
+  const disabled = new Set(disabledIntents);
+  return intents.filter((intent) => !disabled.has(intent));
+};

--- a/packages/core/test/intents.test.ts
+++ b/packages/core/test/intents.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { GatewayIntentBits } from "discord.js";
+import { filterDisabledIntents } from "../src/intents/util";
+
+describe("filterDisabledIntents", () => {
+  test("removes temporarily disabled privileged intents", () => {
+    const intents = filterDisabledIntents(
+      [
+        GatewayIntentBits.Guilds,
+        GatewayIntentBits.GuildMembers,
+        GatewayIntentBits.GuildMessages,
+        GatewayIntentBits.MessageContent,
+      ],
+      [GatewayIntentBits.GuildMembers, GatewayIntentBits.MessageContent],
+    );
+
+    expect(intents).toEqual([
+      GatewayIntentBits.Guilds,
+      GatewayIntentBits.GuildMessages,
+    ]);
+  });
+
+  test("keeps intents when none are disabled", () => {
+    const intents = [GatewayIntentBits.GuildMembers, GatewayIntentBits.MessageContent];
+
+    expect(filterDisabledIntents(intents, [])).toEqual(intents);
+  });
+});

--- a/packages/env/index.ts
+++ b/packages/env/index.ts
@@ -13,6 +13,11 @@ const SpaceSeparatedArray = <
     v.array(matcher),
   );
 
+const BooleanString = v.pipe(
+  v.optional(v.union([v.literal("true"), v.literal("false")]), "false"),
+  v.transform((value) => value === "true"),
+);
+
 const Env = v.object({
   NODE_ENV: v.exactOptional(
     v.union([v.literal("development"), v.literal("production"), v.literal("test")]),
@@ -28,6 +33,7 @@ const Env = v.object({
   SHLINK_API_KEY: v.optional(v.string()),
   SHLINK_API_URL: v.optional(v.pipe(v.string(), v.url())),
   UNBELIEVABOAT_TOKEN: v.optional(v.string()),
+  BOT_PRIVILEGED_INTENTS_ENABLED: BooleanString,
 });
 
 export default v.parse(Env, process.env);


### PR DESCRIPTION
## Summary

- stop requesting the `GuildMembers` and `MessageContent` gateway intents by default
- add the reversible `BOT_PRIVILEGED_INTENTS_ENABLED` environment switch
- pause member-list and arbitrary-message-content features while safe mode is active
- keep exempt and metadata-only functionality working, including DMs, bot mentions, slash commands, sticky messages, and targeted member fetches
- return a clear temporary-unavailable response from commands that require complete member enumeration
- add coverage for filtering disabled gateway intents

## Why

Discord no longer approves these privileged intents for the bot at its current scale. Continuing to include either bit in the gateway identify payload prevents the bot from connecting. Complete member-list operations also need to be avoided while the member intent is unavailable.

## Impact

Join/leave/update member automation, complete role/member enumeration, arbitrary guild-message logging, emoji counting, embed reminders, the pear trigger, and AI access to arbitrary replied/fetched messages are temporarily paused.

The previous behavior can be restored by setting `BOT_PRIVILEGED_INTENTS_ENABLED=true`, re-enabling or obtaining approval for both intents in the Discord Developer Portal, and restarting the bot.

## Validation

- `bunx biome check` on all changed files
- `bun run typecheck`
- `bun test` — 364 passed, 1 skipped, 0 failed
- pre-push formatting and type-check hooks passed