### PR TITLE
feat(birthday2026): add human Tucznik identity

### DIFF
--- a/apps/bot/src/events/birthday2026/index.ts
+++ b/apps/bot/src/events/birthday2026/index.ts
@@ -30,6 +30,7 @@ import {
   findBirthday2026Teams,
   removeBirthday2026Member,
   setBirthday2026Captain,
+  setBirthday2026Tucznik,
 } from "./teamService";
 
 const teamErrorMessages = {
@@ -45,6 +46,10 @@ const teamErrorMessages = {
   role_already_used: "Ta rola jest już używana przez drużynę eventową.",
   team_already_exists: "Drużyna o tej nazwie już istnieje na serwerze.",
   team_not_found: "Nie znaleziono wskazanej drużyny.",
+  tucznik_already_assigned: "Ten użytkownik jest już Tucznikiem innej drużyny.",
+  tucznik_move_requires_replacement:
+    "Najpierw wyznacz innego Tucznika dla tej drużyny.",
+  tucznik_not_member: "Tucznik musi należeć do wskazanej drużyny.",
 };
 
 const economyErrorMessages: Record<Birthday2026EconomyErrorReason, string> = {
@@ -90,11 +95,20 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
 
             const teams = await findBirthday2026Teams(prisma, itx.guildId);
             const now = new Date();
+            const configuredTucznicy = teams.filter(
+              (team) => team.identity !== null,
+            ).length;
+            const tucznicyReady =
+              teams.length === 4 && configuredTucznicy === teams.length;
             const teamLines = teams.map(
               (team) =>
-                `${roleMention(team.roleId)} — ${team._count.memberStates} os. — kapitan: ${
-                  team.captainUserId
-                    ? userMention(team.captainUserId)
+                `${roleMention(team.roleId)} — ${team._count.memberStates} os. — Tucznik: ${
+                  team.identity
+                    ? userMention(team.identity.tucznikUserId)
+                    : "nie wyznaczono"
+                } — kapitan: ${
+                  team.identity
+                    ? userMention(team.identity.captainUserId)
                     : "nie wyznaczono"
                 }`,
             );
@@ -109,6 +123,7 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
                 `${bold("Start:")} ${time(config.eventStartAt, TimestampStyles.LongDateTime)}`,
                 `${bold("Koniec:")} ${time(config.eventEndAt, TimestampStyles.LongDateTime)}`,
                 `${bold("Strefa:")} ${config.timezone}`,
+                `${bold("Tucznicy:")} ${configuredTucznicy}/4 — gotowość: ${tucznicyReady ? "tak" : "nie"}`,
                 `${bold("Drużyny:")}`,
                 teamLines.join("\n") || "brak",
               ].join("\n"),
@@ -512,9 +527,40 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
             );
           }),
       )
-      .addCommand("usun-kapitana", (command) =>
+      .addCommand("tucznik", (command) =>
         command
-          .setDescription("Usuń obecnego kapitana drużyny")
+          .setDescription("Wyznacz albo zastąp Tucznika i ustaw go kapitanem")
+          .addUser("user", (option) => option.setDescription("Nowy Tucznik"))
+          .addRole("druzyna", (option) => option.setDescription("Rola drużyny"))
+          .handle(async ({ prisma }, { user, druzyna: role }, itx) => {
+            if (!itx.inCachedGuild()) return;
+            await itx.deferReply({ flags: "Ephemeral" });
+
+            const team = await findTeamByRole(prisma, itx.guildId, role.id);
+            if (!team) {
+              await errorFollowUp(itx, "Ta rola nie jest drużyną tego eventu.");
+              return;
+            }
+
+            const result = await setBirthday2026Tucznik(
+              prisma,
+              itx.guildId,
+              team.id,
+              user.id,
+            );
+            if (!result.ok) {
+              await replyWithTeamError(itx, result.reason);
+              return;
+            }
+
+            await itx.editReply(
+              `${userMention(user.id)} jest Tucznikiem i kapitanem ${roleMention(team.roleId)}.`,
+            );
+          }),
+      )
+      .addCommand("usun-tucznika", (command) =>
+        command
+          .setDescription("Usuń konfigurację Tucznika i kapitana drużyny")
           .addRole("druzyna", (option) => option.setDescription("Rola drużyny"))
           .handle(async ({ prisma }, { druzyna: role }, itx) => {
             if (!itx.inCachedGuild()) return;
@@ -526,7 +572,7 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
               return;
             }
 
-            const result = await setBirthday2026Captain(
+            const result = await setBirthday2026Tucznik(
               prisma,
               itx.guildId,
               team.id,
@@ -536,8 +582,9 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
               await errorFollowUp(itx, teamErrorMessages[result.reason]);
               return;
             }
+
             await itx.editReply(
-              `Usunięto kapitana drużyny ${roleMention(team.roleId)}.`,
+              `Usunięto konfigurację Tucznika i kapitana drużyny ${roleMention(team.roleId)}.`,
             );
           }),
       ),

--- a/apps/bot/src/events/birthday2026/index.ts
+++ b/apps/bot/src/events/birthday2026/index.ts
@@ -549,7 +549,7 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
               user.id,
             );
             if (!result.ok) {
-              await replyWithTeamError(itx, result.reason);
+              await errorFollowUp(itx, teamErrorMessages[result.reason]);
               return;
             }
 

--- a/apps/bot/src/events/birthday2026/index.ts
+++ b/apps/bot/src/events/birthday2026/index.ts
@@ -27,6 +27,7 @@ import { parseBirthday2026Instant } from "./staffInput";
 import {
   assignBirthday2026Member,
   createBirthday2026Team,
+  createBirthday2026TeamIdentity,
   findBirthday2026Teams,
   removeBirthday2026Member,
   setBirthday2026Captain,
@@ -37,9 +38,14 @@ const teamErrorMessages = {
   already_in_team: "Ten użytkownik jest już w tej drużynie.",
   captain_already_assigned: "Ten użytkownik jest już kapitanem innej drużyny.",
   captain_move_requires_replacement:
-    "Najpierw wyznacz zastępstwo albo usuń kapitana tej drużyny.",
+    "Najpierw wyznacz zastępstwo kapitana tej drużyny.",
   captain_not_member: "Kapitan musi należeć do wskazanej drużyny.",
   config_not_found: "Event urodzinowy nie jest jeszcze skonfigurowany.",
+  identity_already_assigned:
+    "Tucznik albo kapitan jest już przypisany do innej drużyny.",
+  identity_already_configured:
+    "Tucznik i kapitan tej drużyny są już ustawieni. Zmieniaj ich osobno.",
+  identity_not_configured: "Najpierw ustaw Tucznika i kapitana tej drużyny razem.",
   invalid_activity_estimate: "Nie udało się obliczyć aktywności uczestnika.",
   member_not_found: "Ten użytkownik nie należy do żadnej drużyny.",
   no_teams: "Event nie ma jeszcze skonfigurowanych drużyn.",
@@ -496,6 +502,43 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
             );
           }),
       )
+      .addCommand("tozsamosc", (command) =>
+        command
+          .setDescription("Ustaw Tucznika i kapitana drużyny")
+          .addUser("tucznik", (option) => option.setDescription("Tucznik"))
+          .addUser("kapitan", (option) => option.setDescription("Kapitan"))
+          .addRole("druzyna", (option) => option.setDescription("Rola drużyny"))
+          .handle(async ({ prisma }, { tucznik, kapitan, druzyna: role }, itx) => {
+            if (!itx.inCachedGuild()) return;
+            await itx.deferReply({ flags: "Ephemeral" });
+
+            const team = await findTeamByRole(prisma, itx.guildId, role.id);
+
+            if (!team) {
+              await errorFollowUp(itx, "Ta rola nie jest drużyną tego eventu.");
+              return;
+            }
+
+            const result = await createBirthday2026TeamIdentity(
+              prisma,
+              itx.guildId,
+              team.id,
+              {
+                captainUserId: kapitan.id,
+                tucznikUserId: tucznik.id,
+              },
+            );
+
+            if (!result.ok) {
+              await errorFollowUp(itx, teamErrorMessages[result.reason]);
+              return;
+            }
+
+            await itx.editReply(
+              `${userMention(tucznik.id)} jest Tucznikiem, a ${userMention(kapitan.id)} kapitanem ${roleMention(team.roleId)}.`,
+            );
+          }),
+      )
       .addCommand("kapitan", (command) =>
         command
           .setDescription("Wyznacz albo zastąp kapitana drużyny")
@@ -555,36 +598,6 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
 
             await itx.editReply(
               `${userMention(user.id)} jest Tucznikiem ${roleMention(team.roleId)}.`,
-            );
-          }),
-      )
-      .addCommand("usun-tucznika", (command) =>
-        command
-          .setDescription("Usuń konfigurację Tucznika drużyny")
-          .addRole("druzyna", (option) => option.setDescription("Rola drużyny"))
-          .handle(async ({ prisma }, { druzyna: role }, itx) => {
-            if (!itx.inCachedGuild()) return;
-            await itx.deferReply({ flags: "Ephemeral" });
-
-            const team = await findTeamByRole(prisma, itx.guildId, role.id);
-            if (!team) {
-              await errorFollowUp(itx, "Ta rola nie jest drużyną tego eventu.");
-              return;
-            }
-
-            const result = await setBirthday2026Tucznik(
-              prisma,
-              itx.guildId,
-              team.id,
-              null,
-            );
-            if (!result.ok) {
-              await errorFollowUp(itx, teamErrorMessages[result.reason]);
-              return;
-            }
-
-            await itx.editReply(
-              `Usunięto konfigurację Tucznika drużyny ${roleMention(team.roleId)}.`,
             );
           }),
       ),

--- a/apps/bot/src/events/birthday2026/index.ts
+++ b/apps/bot/src/events/birthday2026/index.ts
@@ -95,19 +95,19 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
 
             const teams = await findBirthday2026Teams(prisma, itx.guildId);
             const now = new Date();
-            const configuredTucznicy = teams.filter(
-              (team) => team.identity !== null,
+            const configuredTucznicy = teams.filter((team) =>
+              Boolean(team.identity?.tucznikUserId),
             ).length;
             const tucznicyReady =
-              teams.length === 4 && configuredTucznicy === teams.length;
+              teams.length > 0 && configuredTucznicy === teams.length;
             const teamLines = teams.map(
               (team) =>
                 `${roleMention(team.roleId)} — ${team._count.memberStates} os. — Tucznik: ${
-                  team.identity
+                  team.identity?.tucznikUserId
                     ? userMention(team.identity.tucznikUserId)
                     : "nie wyznaczono"
                 } — kapitan: ${
-                  team.identity
+                  team.identity?.captainUserId
                     ? userMention(team.identity.captainUserId)
                     : "nie wyznaczono"
                 }`,
@@ -123,7 +123,7 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
                 `${bold("Start:")} ${time(config.eventStartAt, TimestampStyles.LongDateTime)}`,
                 `${bold("Koniec:")} ${time(config.eventEndAt, TimestampStyles.LongDateTime)}`,
                 `${bold("Strefa:")} ${config.timezone}`,
-                `${bold("Tucznicy:")} ${configuredTucznicy}/4 — gotowość: ${tucznicyReady ? "tak" : "nie"}`,
+                `${bold("Tucznicy:")} ${configuredTucznicy}/${teams.length} — gotowość: ${tucznicyReady ? "tak" : "nie"}`,
                 `${bold("Drużyny:")}`,
                 teamLines.join("\n") || "brak",
               ].join("\n"),
@@ -529,7 +529,7 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
       )
       .addCommand("tucznik", (command) =>
         command
-          .setDescription("Wyznacz albo zastąp Tucznika i ustaw go kapitanem")
+          .setDescription("Wyznacz albo zastąp Tucznika")
           .addUser("user", (option) => option.setDescription("Nowy Tucznik"))
           .addRole("druzyna", (option) => option.setDescription("Rola drużyny"))
           .handle(async ({ prisma }, { user, druzyna: role }, itx) => {
@@ -554,13 +554,13 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
             }
 
             await itx.editReply(
-              `${userMention(user.id)} jest Tucznikiem i kapitanem ${roleMention(team.roleId)}.`,
+              `${userMention(user.id)} jest Tucznikiem ${roleMention(team.roleId)}.`,
             );
           }),
       )
       .addCommand("usun-tucznika", (command) =>
         command
-          .setDescription("Usuń konfigurację Tucznika i kapitana drużyny")
+          .setDescription("Usuń konfigurację Tucznika drużyny")
           .addRole("druzyna", (option) => option.setDescription("Rola drużyny"))
           .handle(async ({ prisma }, { druzyna: role }, itx) => {
             if (!itx.inCachedGuild()) return;
@@ -584,7 +584,7 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
             }
 
             await itx.editReply(
-              `Usunięto konfigurację Tucznika i kapitana drużyny ${roleMention(team.roleId)}.`,
+              `Usunięto konfigurację Tucznika drużyny ${roleMention(team.roleId)}.`,
             );
           }),
       ),

--- a/apps/bot/src/events/birthday2026/teamService.ts
+++ b/apps/bot/src/events/birthday2026/teamService.ts
@@ -1,4 +1,5 @@
 import {
+  type Birthday2026TeamIdentity,
   type ExtendedPrismaClient,
   isUniqueConstraintError,
   type PrismaTransaction,
@@ -145,6 +146,7 @@ export const findBirthday2026Teams = (prisma: PrismaTransaction, guildId: string
     where: { config: { guildId } },
     include: {
       team: true,
+      identity: true,
       _count: { select: { memberStates: true } },
     },
     orderBy: { id: "asc" },
@@ -157,7 +159,14 @@ export const findBirthday2026Membership = (
 ) =>
   prisma.birthday2026MemberState.findFirst({
     where: { userId, teamConfig: { config: { guildId } } },
-    include: { teamConfig: { include: { team: true } } },
+    include: {
+      teamConfig: {
+        include: {
+          team: true,
+          identity: true,
+        },
+      },
+    },
   });
 
 export const createBirthday2026Team = async (
@@ -243,14 +252,27 @@ export const assignBirthday2026Member = (
         },
       },
       include: {
-        teamConfig: { select: { captainUserId: true, roleId: true } },
+        teamConfig: {
+          select: {
+            roleId: true,
+            identity: {
+              select: {
+                captainUserId: true,
+                tucznikUserId: true,
+              },
+            },
+          },
+        },
       },
     });
     if (existing?.teamConfigId === input.teamConfigId) {
       return { ok: false, reason: "already_in_team" } as const;
     }
-    if (existing?.teamConfig.captainUserId === input.userId) {
+    if (existing?.teamConfig.identity?.captainUserId === input.userId) {
       return { ok: false, reason: "captain_move_requires_replacement" } as const;
+    }
+    if (existing?.teamConfig.identity?.tucznikUserId === input.userId) {
+      return { ok: false, reason: "tucznik_move_requires_replacement" } as const;
     }
 
     const member = await tx.birthday2026MemberState.upsert({
@@ -282,8 +304,11 @@ export const removeBirthday2026Member = async (
 ) => {
   const member = await findBirthday2026Membership(prisma, guildId, userId);
   if (!member) return { ok: false, reason: "member_not_found" } as const;
-  if (member.teamConfig.captainUserId === userId) {
+  if (member.teamConfig.identity?.captainUserId === userId) {
     return { ok: false, reason: "captain_move_requires_replacement" } as const;
+  }
+  if (member.teamConfig.identity?.tucznikUserId === userId) {
+    return { ok: false, reason: "tucznik_move_requires_replacement" } as const;
   }
 
   await prisma.birthday2026MemberState.delete({ where: { id: member.id } });
@@ -294,35 +319,49 @@ export const setBirthday2026Captain = async (
   prisma: ExtendedPrismaClient,
   guildId: string,
   teamConfigId: number,
-  userId: string | null,
+  userId: string,
 ) => {
   try {
     return await prisma.$transaction(async (tx) => {
       const teamConfig = await tx.birthday2026TeamConfig.findFirst({
         where: { id: teamConfigId, config: { guildId } },
-        select: { id: true, configId: true },
+        select: {
+          id: true,
+          configId: true,
+          identity: { select: { teamConfigId: true } },
+        },
       });
       if (!teamConfig) return { ok: false, reason: "team_not_found" } as const;
 
-      if (userId) {
-        const membership = await tx.birthday2026MemberState.findUnique({
-          where: {
-            configId_userId: {
-              configId: teamConfig.configId,
-              userId,
-            },
+      const membership = await tx.birthday2026MemberState.findUnique({
+        where: {
+          configId_userId: {
+            configId: teamConfig.configId,
+            userId,
           },
-        });
-        if (!membership || membership.teamConfigId !== teamConfig.id) {
-          return { ok: false, reason: "captain_not_member" } as const;
-        }
+        },
+      });
+      if (!membership || membership.teamConfigId !== teamConfig.id) {
+        return { ok: false, reason: "captain_not_member" } as const;
       }
 
-      const team = await tx.birthday2026TeamConfig.update({
+      const identity = teamConfig.identity
+        ? await tx.birthday2026TeamIdentity.update({
+            where: { teamConfigId: teamConfig.id },
+            data: { captainUserId: userId },
+          })
+        : await tx.birthday2026TeamIdentity.create({
+            data: {
+              teamConfigId: teamConfig.id,
+              configId: teamConfig.configId,
+              tucznikUserId: userId,
+              captainUserId: userId,
+            },
+          });
+      const team = await tx.birthday2026TeamConfig.findUniqueOrThrow({
         where: { id: teamConfig.id },
-        data: { captainUserId: userId },
       });
-      return { ok: true, team } as const;
+      return { ok: true, team, identity } as const;
     });
   } catch (error) {
     if (isUniqueConstraintError(error)) {
@@ -331,6 +370,84 @@ export const setBirthday2026Captain = async (
     throw error;
   }
 };
+
+export const setBirthday2026Tucznik = (
+  prisma: ExtendedPrismaClient,
+  guildId: string,
+  teamConfigId: number,
+  userId: string | null,
+) =>
+  prisma.$transaction(async (tx) => {
+    const teamConfig = await tx.birthday2026TeamConfig.findFirst({
+      where: { id: teamConfigId, config: { guildId } },
+      select: { id: true, configId: true },
+    });
+    if (!teamConfig) return { ok: false, reason: "team_not_found" } as const;
+
+    if (userId) {
+      const membership = await tx.birthday2026MemberState.findUnique({
+        where: {
+          configId_userId: {
+            configId: teamConfig.configId,
+            userId,
+          },
+        },
+      });
+      if (!membership || membership.teamConfigId !== teamConfig.id) {
+        return { ok: false, reason: "tucznik_not_member" } as const;
+      }
+
+      const [existingTucznik, existingCaptaincy] = await Promise.all([
+        tx.birthday2026TeamIdentity.findFirst({
+          where: {
+            configId: teamConfig.configId,
+            tucznikUserId: userId,
+            teamConfigId: { not: teamConfig.id },
+          },
+          select: { teamConfigId: true },
+        }),
+        tx.birthday2026TeamIdentity.findFirst({
+          where: {
+            configId: teamConfig.configId,
+            captainUserId: userId,
+            teamConfigId: { not: teamConfig.id },
+          },
+          select: { teamConfigId: true },
+        }),
+      ]);
+      if (existingTucznik) {
+        return { ok: false, reason: "tucznik_already_assigned" } as const;
+      }
+      if (existingCaptaincy) {
+        return { ok: false, reason: "captain_already_assigned" } as const;
+      }
+    }
+
+    let identity: Birthday2026TeamIdentity | null = null;
+    if (userId) {
+      identity = await tx.birthday2026TeamIdentity.upsert({
+        where: { teamConfigId: teamConfig.id },
+        create: {
+          teamConfigId: teamConfig.id,
+          configId: teamConfig.configId,
+          tucznikUserId: userId,
+          captainUserId: userId,
+        },
+        update: {
+          tucznikUserId: userId,
+          captainUserId: userId,
+        },
+      });
+    } else {
+      await tx.birthday2026TeamIdentity.deleteMany({
+        where: { teamConfigId: teamConfig.id },
+      });
+    }
+    const team = await tx.birthday2026TeamConfig.findUniqueOrThrow({
+      where: { id: teamConfig.id },
+    });
+    return { ok: true, team, identity } as const;
+  });
 
 export const rebalanceBirthday2026Members = (
   prisma: ExtendedPrismaClient,
@@ -345,7 +462,10 @@ export const rebalanceBirthday2026Members = (
       where: { guildId: input.guildId },
       include: {
         teams: {
-          include: { memberStates: true },
+          include: {
+            identity: true,
+            memberStates: true,
+          },
           orderBy: { id: "asc" },
         },
       },
@@ -369,7 +489,8 @@ export const rebalanceBirthday2026Members = (
         members.push({
           userId: member.userId,
           activityEstimate,
-          ...(team.captainUserId === member.userId
+          ...(team.identity?.captainUserId === member.userId ||
+          team.identity?.tucznikUserId === member.userId
             ? { fixedTeamConfigId: team.id }
             : {}),
         });
@@ -377,10 +498,20 @@ export const rebalanceBirthday2026Members = (
     }
     for (const team of config.teams) {
       if (
-        team.captainUserId &&
-        !team.memberStates.some((member) => member.userId === team.captainUserId)
+        team.identity?.captainUserId &&
+        !team.memberStates.some(
+          (member) => member.userId === team.identity?.captainUserId,
+        )
       ) {
         return { ok: false, reason: "captain_not_member" } as const;
+      }
+      if (
+        team.identity?.tucznikUserId &&
+        !team.memberStates.some(
+          (member) => member.userId === team.identity?.tucznikUserId,
+        )
+      ) {
+        return { ok: false, reason: "tucznik_not_member" } as const;
       }
     }
 

--- a/apps/bot/src/events/birthday2026/teamService.ts
+++ b/apps/bot/src/events/birthday2026/teamService.ts
@@ -1,5 +1,4 @@
 import {
-  type Birthday2026TeamIdentity,
   type ExtendedPrismaClient,
   isUniqueConstraintError,
   type PrismaTransaction,
@@ -315,6 +314,78 @@ export const removeBirthday2026Member = async (
   return { ok: true, member } as const;
 };
 
+export const createBirthday2026TeamIdentity = async (
+  prisma: ExtendedPrismaClient,
+  guildId: string,
+  teamConfigId: number,
+  input: {
+    captainUserId: string;
+    tucznikUserId: string;
+  },
+) => {
+  try {
+    return await prisma.$transaction(async (tx) => {
+      const teamConfig = await tx.birthday2026TeamConfig.findFirst({
+        where: { id: teamConfigId, config: { guildId } },
+        select: {
+          id: true,
+          configId: true,
+          identity: { select: { teamConfigId: true } },
+        },
+      });
+
+      if (!teamConfig) return { ok: false, reason: "team_not_found" } as const;
+
+      if (teamConfig.identity) {
+        return { ok: false, reason: "identity_already_configured" } as const;
+      }
+
+      const [captainMembership, tucznikMembership] = await Promise.all([
+        tx.birthday2026MemberState.findUnique({
+          where: {
+            configId_userId: {
+              configId: teamConfig.configId,
+              userId: input.captainUserId,
+            },
+          },
+        }),
+        tx.birthday2026MemberState.findUnique({
+          where: {
+            configId_userId: {
+              configId: teamConfig.configId,
+              userId: input.tucznikUserId,
+            },
+          },
+        }),
+      ]);
+
+      if (!captainMembership || captainMembership.teamConfigId !== teamConfig.id) {
+        return { ok: false, reason: "captain_not_member" } as const;
+      }
+
+      if (!tucznikMembership || tucznikMembership.teamConfigId !== teamConfig.id) {
+        return { ok: false, reason: "tucznik_not_member" } as const;
+      }
+
+      const identity = await tx.birthday2026TeamIdentity.create({
+        data: {
+          teamConfigId: teamConfig.id,
+          configId: teamConfig.configId,
+          tucznikUserId: input.tucznikUserId,
+          captainUserId: input.captainUserId,
+        },
+      });
+
+      return { ok: true, identity } as const;
+    });
+  } catch (error) {
+    if (isUniqueConstraintError(error)) {
+      return { ok: false, reason: "identity_already_assigned" } as const;
+    }
+    throw error;
+  }
+};
+
 export const setBirthday2026Captain = async (
   prisma: ExtendedPrismaClient,
   guildId: string,
@@ -344,24 +415,15 @@ export const setBirthday2026Captain = async (
       if (!membership || membership.teamConfigId !== teamConfig.id) {
         return { ok: false, reason: "captain_not_member" } as const;
       }
+      if (!teamConfig.identity) {
+        return { ok: false, reason: "identity_not_configured" } as const;
+      }
 
-      const identity = teamConfig.identity
-        ? await tx.birthday2026TeamIdentity.update({
-            where: { teamConfigId: teamConfig.id },
-            data: { captainUserId: userId },
-          })
-        : await tx.birthday2026TeamIdentity.create({
-            data: {
-              teamConfigId: teamConfig.id,
-              configId: teamConfig.configId,
-              tucznikUserId: userId,
-              captainUserId: userId,
-            },
-          });
-      const team = await tx.birthday2026TeamConfig.findUniqueOrThrow({
-        where: { id: teamConfig.id },
+      const identity = await tx.birthday2026TeamIdentity.update({
+        where: { teamConfigId: teamConfig.id },
+        data: { captainUserId: userId },
       });
-      return { ok: true, team, identity } as const;
+      return { ok: true, identity } as const;
     });
   } catch (error) {
     if (isUniqueConstraintError(error)) {
@@ -375,16 +437,19 @@ export const setBirthday2026Tucznik = (
   prisma: ExtendedPrismaClient,
   guildId: string,
   teamConfigId: number,
-  userId: string | null,
+  userId: string,
 ) =>
-  prisma.$transaction(async (tx) => {
-    const teamConfig = await tx.birthday2026TeamConfig.findFirst({
-      where: { id: teamConfigId, config: { guildId } },
-      select: { id: true, configId: true },
-    });
-    if (!teamConfig) return { ok: false, reason: "team_not_found" } as const;
-
-    if (userId) {
+  prisma
+    .$transaction(async (tx) => {
+      const teamConfig = await tx.birthday2026TeamConfig.findFirst({
+        where: { id: teamConfigId, config: { guildId } },
+        select: {
+          id: true,
+          configId: true,
+          identity: { select: { teamConfigId: true } },
+        },
+      });
+      if (!teamConfig) return { ok: false, reason: "team_not_found" } as const;
       const membership = await tx.birthday2026MemberState.findUnique({
         where: {
           configId_userId: {
@@ -396,58 +461,22 @@ export const setBirthday2026Tucznik = (
       if (!membership || membership.teamConfigId !== teamConfig.id) {
         return { ok: false, reason: "tucznik_not_member" } as const;
       }
+      if (!teamConfig.identity) {
+        return { ok: false, reason: "identity_not_configured" } as const;
+      }
 
-      const [existingTucznik, existingCaptaincy] = await Promise.all([
-        tx.birthday2026TeamIdentity.findFirst({
-          where: {
-            configId: teamConfig.configId,
-            tucznikUserId: userId,
-            teamConfigId: { not: teamConfig.id },
-          },
-          select: { teamConfigId: true },
-        }),
-        tx.birthday2026TeamIdentity.findFirst({
-          where: {
-            configId: teamConfig.configId,
-            captainUserId: userId,
-            teamConfigId: { not: teamConfig.id },
-          },
-          select: { teamConfigId: true },
-        }),
-      ]);
-      if (existingTucznik) {
+      const identity = await tx.birthday2026TeamIdentity.update({
+        where: { teamConfigId: teamConfig.id },
+        data: { tucznikUserId: userId },
+      });
+      return { ok: true, identity } as const;
+    })
+    .catch((error) => {
+      if (isUniqueConstraintError(error)) {
         return { ok: false, reason: "tucznik_already_assigned" } as const;
       }
-      if (existingCaptaincy) {
-        return { ok: false, reason: "captain_already_assigned" } as const;
-      }
-    }
-
-    let identity: Birthday2026TeamIdentity | null = null;
-    if (userId) {
-      identity = await tx.birthday2026TeamIdentity.upsert({
-        where: { teamConfigId: teamConfig.id },
-        create: {
-          teamConfigId: teamConfig.id,
-          configId: teamConfig.configId,
-          tucznikUserId: userId,
-          captainUserId: userId,
-        },
-        update: {
-          tucznikUserId: userId,
-          captainUserId: userId,
-        },
-      });
-    } else {
-      await tx.birthday2026TeamIdentity.deleteMany({
-        where: { teamConfigId: teamConfig.id },
-      });
-    }
-    const team = await tx.birthday2026TeamConfig.findUniqueOrThrow({
-      where: { id: teamConfig.id },
+      throw error;
     });
-    return { ok: true, team, identity } as const;
-  });
 
 export const rebalanceBirthday2026Members = (
   prisma: ExtendedPrismaClient,

--- a/apps/bot/test/birthday2026/teamService.database.test.ts
+++ b/apps/bot/test/birthday2026/teamService.database.test.ts
@@ -9,6 +9,7 @@ import {
   rebalanceBirthday2026Members,
   removeBirthday2026Member,
   setBirthday2026Captain,
+  setBirthday2026Tucznik,
 } from "../../src/events/birthday2026/teamService";
 
 const connectionString = process.env.DATABASE_TEST_URL;
@@ -200,6 +201,139 @@ databaseTests("Birthday 2026 team services", () => {
       ok: false,
       reason: "captain_move_requires_replacement",
     });
+  });
+
+  it("appoints a Tucznik as captain and preserves the identity across captain replacement", async () => {
+    if (!prisma) throw new Error("DATABASE_TEST_URL is required");
+    const fixture = await createFixture(4);
+    const tucznikUserId = requiredItem(fixture.users, 0, "Tucznik fixture user");
+    const replacementCaptainUserId = requiredItem(
+      fixture.users,
+      1,
+      "replacement captain fixture user",
+    );
+    const otherTeamUserId = requiredItem(fixture.users, 2, "other team fixture user");
+    const movableUserId = requiredItem(fixture.users, 3, "movable fixture user");
+    const first = await createTeam(
+      fixture.guildId,
+      `First ${fixture.suffix}`,
+      `first-role-${fixture.suffix}`,
+      0xff0000,
+    );
+    const second = await createTeam(
+      fixture.guildId,
+      `Second ${fixture.suffix}`,
+      `second-role-${fixture.suffix}`,
+      0x00ff00,
+    );
+
+    await Promise.all([
+      assignBirthday2026Member(prisma, {
+        guildId: fixture.guildId,
+        teamConfigId: first.id,
+        userId: tucznikUserId,
+      }),
+      assignBirthday2026Member(prisma, {
+        guildId: fixture.guildId,
+        teamConfigId: first.id,
+        userId: replacementCaptainUserId,
+      }),
+      assignBirthday2026Member(prisma, {
+        guildId: fixture.guildId,
+        teamConfigId: second.id,
+        userId: otherTeamUserId,
+      }),
+      assignBirthday2026Member(prisma, {
+        guildId: fixture.guildId,
+        teamConfigId: second.id,
+        userId: movableUserId,
+      }),
+    ]);
+
+    expect(
+      await setBirthday2026Tucznik(prisma, fixture.guildId, first.id, otherTeamUserId),
+    ).toEqual({ ok: false, reason: "tucznik_not_member" });
+
+    const appointment = await setBirthday2026Tucznik(
+      prisma,
+      fixture.guildId,
+      first.id,
+      tucznikUserId,
+    );
+    expect(appointment).toMatchObject({
+      ok: true,
+      identity: {
+        tucznikUserId,
+        captainUserId: tucznikUserId,
+      },
+    });
+
+    const captainReplacement = await setBirthday2026Captain(
+      prisma,
+      fixture.guildId,
+      first.id,
+      replacementCaptainUserId,
+    );
+    expect(captainReplacement).toMatchObject({
+      ok: true,
+      identity: {
+        tucznikUserId,
+        captainUserId: replacementCaptainUserId,
+      },
+    });
+
+    expect(
+      await assignBirthday2026Member(prisma, {
+        guildId: fixture.guildId,
+        teamConfigId: second.id,
+        userId: tucznikUserId,
+      }),
+    ).toEqual({
+      ok: false,
+      reason: "tucznik_move_requires_replacement",
+    });
+    expect(
+      await removeBirthday2026Member(prisma, fixture.guildId, tucznikUserId),
+    ).toEqual({
+      ok: false,
+      reason: "tucznik_move_requires_replacement",
+    });
+
+    const rebalance = await rebalanceBirthday2026Members(prisma, {
+      guildId: fixture.guildId,
+      activityEstimates: new Map(
+        fixture.users.map((userId, index) => [userId, 100 - index * 10]),
+      ),
+      random: () => 0,
+    });
+    if (!rebalance.ok) throw new Error(rebalance.reason);
+    expect(
+      rebalance.plan.assignments.find(
+        (assignment) => assignment.userId === tucznikUserId,
+      )?.teamConfigId,
+    ).toBe(first.id);
+    expect(
+      rebalance.plan.assignments.find(
+        (assignment) => assignment.userId === replacementCaptainUserId,
+      )?.teamConfigId,
+    ).toBe(first.id);
+
+    const cleared = await setBirthday2026Tucznik(
+      prisma,
+      fixture.guildId,
+      first.id,
+      null,
+    );
+    expect(cleared).toEqual({
+      ok: true,
+      team: expect.objectContaining({ id: first.id }),
+      identity: null,
+    });
+    expect(
+      await prisma.birthday2026TeamIdentity.findUnique({
+        where: { teamConfigId: first.id },
+      }),
+    ).toBeNull();
   });
 
   it("rebalances members atomically while pinning captains", async () => {

--- a/apps/bot/test/birthday2026/teamService.database.test.ts
+++ b/apps/bot/test/birthday2026/teamService.database.test.ts
@@ -5,6 +5,7 @@ import { upsertBirthday2026Config } from "../../src/events/birthday2026/configSe
 import {
   assignBirthday2026Member,
   createBirthday2026Team,
+  createBirthday2026TeamIdentity,
   findBirthday2026Membership,
   rebalanceBirthday2026Members,
   removeBirthday2026Member,
@@ -158,6 +159,7 @@ databaseTests("Birthday 2026 team services", () => {
     if (!prisma) throw new Error("DATABASE_TEST_URL is required");
     const fixture = await createFixture(2);
     const captainUserId = requiredItem(fixture.users, 0, "captain fixture user");
+    const tucznikUserId = requiredItem(fixture.users, 1, "Tucznik fixture user");
     const first = await createTeam(
       fixture.guildId,
       `First ${fixture.suffix}`,
@@ -180,6 +182,20 @@ databaseTests("Birthday 2026 team services", () => {
       teamConfigId: first.id,
       userId: captainUserId,
     });
+    await assignBirthday2026Member(prisma, {
+      guildId: fixture.guildId,
+      teamConfigId: first.id,
+      userId: tucznikUserId,
+    });
+    expect(
+      await setBirthday2026Captain(prisma, fixture.guildId, first.id, captainUserId),
+    ).toEqual({ ok: false, reason: "identity_not_configured" });
+    expect(
+      await createBirthday2026TeamIdentity(prisma, fixture.guildId, first.id, {
+        captainUserId,
+        tucznikUserId,
+      }),
+    ).toMatchObject({ ok: true });
     expect(
       (await setBirthday2026Captain(prisma, fixture.guildId, first.id, captainUserId))
         .ok,
@@ -203,17 +219,22 @@ databaseTests("Birthday 2026 team services", () => {
     });
   });
 
-  it("appoints a Tucznik as captain and preserves the identity across captain replacement", async () => {
+  it("assigns and replaces the required identities independently", async () => {
     if (!prisma) throw new Error("DATABASE_TEST_URL is required");
-    const fixture = await createFixture(4);
+    const fixture = await createFixture(5);
     const tucznikUserId = requiredItem(fixture.users, 0, "Tucznik fixture user");
     const replacementCaptainUserId = requiredItem(
       fixture.users,
       1,
       "replacement captain fixture user",
     );
-    const otherTeamUserId = requiredItem(fixture.users, 2, "other team fixture user");
-    const movableUserId = requiredItem(fixture.users, 3, "movable fixture user");
+    const replacementTucznikUserId = requiredItem(
+      fixture.users,
+      2,
+      "replacement Tucznik fixture user",
+    );
+    const otherTeamUserId = requiredItem(fixture.users, 3, "other team fixture user");
+    const movableUserId = requiredItem(fixture.users, 4, "movable fixture user");
     const first = await createTeam(
       fixture.guildId,
       `First ${fixture.suffix}`,
@@ -240,6 +261,11 @@ databaseTests("Birthday 2026 team services", () => {
       }),
       assignBirthday2026Member(prisma, {
         guildId: fixture.guildId,
+        teamConfigId: first.id,
+        userId: replacementTucznikUserId,
+      }),
+      assignBirthday2026Member(prisma, {
+        guildId: fixture.guildId,
         teamConfigId: second.id,
         userId: otherTeamUserId,
       }),
@@ -254,31 +280,51 @@ databaseTests("Birthday 2026 team services", () => {
       await setBirthday2026Tucznik(prisma, fixture.guildId, first.id, otherTeamUserId),
     ).toEqual({ ok: false, reason: "tucznik_not_member" });
 
-    const appointment = await setBirthday2026Tucznik(
+    const appointment = await createBirthday2026TeamIdentity(
       prisma,
       fixture.guildId,
       first.id,
-      tucznikUserId,
+      { captainUserId: replacementCaptainUserId, tucznikUserId },
     );
     expect(appointment).toMatchObject({
       ok: true,
       identity: {
         tucznikUserId,
-        captainUserId: tucznikUserId,
+        captainUserId: replacementCaptainUserId,
       },
     });
+    expect(
+      await createBirthday2026TeamIdentity(prisma, fixture.guildId, first.id, {
+        captainUserId: replacementTucznikUserId,
+        tucznikUserId,
+      }),
+    ).toEqual({ ok: false, reason: "identity_already_configured" });
 
     const captainReplacement = await setBirthday2026Captain(
       prisma,
       fixture.guildId,
       first.id,
-      replacementCaptainUserId,
+      replacementTucznikUserId,
     );
     expect(captainReplacement).toMatchObject({
       ok: true,
       identity: {
         tucznikUserId,
-        captainUserId: replacementCaptainUserId,
+        captainUserId: replacementTucznikUserId,
+      },
+    });
+
+    const tucznikReplacement = await setBirthday2026Tucznik(
+      prisma,
+      fixture.guildId,
+      first.id,
+      replacementCaptainUserId,
+    );
+    expect(tucznikReplacement).toMatchObject({
+      ok: true,
+      identity: {
+        tucznikUserId: replacementCaptainUserId,
+        captainUserId: replacementTucznikUserId,
       },
     });
 
@@ -286,14 +332,14 @@ databaseTests("Birthday 2026 team services", () => {
       await assignBirthday2026Member(prisma, {
         guildId: fixture.guildId,
         teamConfigId: second.id,
-        userId: tucznikUserId,
+        userId: replacementCaptainUserId,
       }),
     ).toEqual({
       ok: false,
       reason: "tucznik_move_requires_replacement",
     });
     expect(
-      await removeBirthday2026Member(prisma, fixture.guildId, tucznikUserId),
+      await removeBirthday2026Member(prisma, fixture.guildId, replacementCaptainUserId),
     ).toEqual({
       ok: false,
       reason: "tucznik_move_requires_replacement",
@@ -309,7 +355,7 @@ databaseTests("Birthday 2026 team services", () => {
     if (!rebalance.ok) throw new Error(rebalance.reason);
     expect(
       rebalance.plan.assignments.find(
-        (assignment) => assignment.userId === tucznikUserId,
+        (assignment) => assignment.userId === replacementTucznikUserId,
       )?.teamConfigId,
     ).toBe(first.id);
     expect(
@@ -318,22 +364,14 @@ databaseTests("Birthday 2026 team services", () => {
       )?.teamConfigId,
     ).toBe(first.id);
 
-    const cleared = await setBirthday2026Tucznik(
-      prisma,
-      fixture.guildId,
-      first.id,
-      null,
-    );
-    expect(cleared).toEqual({
-      ok: true,
-      team: expect.objectContaining({ id: first.id }),
-      identity: null,
-    });
     expect(
       await prisma.birthday2026TeamIdentity.findUnique({
         where: { teamConfigId: first.id },
       }),
-    ).toBeNull();
+    ).toMatchObject({
+      tucznikUserId: replacementCaptainUserId,
+      captainUserId: replacementTucznikUserId,
+    });
   });
 
   it("rebalances members atomically while pinning captains", async () => {
@@ -351,6 +389,7 @@ databaseTests("Birthday 2026 team services", () => {
     );
     const captainTeam = requiredItem(teams, 0, "captain team");
     const captainUserId = requiredItem(fixture.users, 0, "captain fixture user");
+    const tucznikUserId = requiredItem(fixture.users, 1, "Tucznik fixture user");
 
     await Promise.all(
       fixture.users.map((userId) =>
@@ -361,13 +400,13 @@ databaseTests("Birthday 2026 team services", () => {
         }),
       ),
     );
-    const captainResult = await setBirthday2026Captain(
+    const identityResult = await createBirthday2026TeamIdentity(
       prisma,
       fixture.guildId,
       captainTeam.id,
-      captainUserId,
+      { captainUserId, tucznikUserId },
     );
-    if (!captainResult.ok) throw new Error(captainResult.reason);
+    if (!identityResult.ok) throw new Error(identityResult.reason);
 
     expect(
       await rebalanceBirthday2026Members(prisma, {

--- a/packages/db/prisma/migrations/20260728120000_add_birthday_2026_tucznik_identity/migration.sql
+++ b/packages/db/prisma/migrations/20260728120000_add_birthday_2026_tucznik_identity/migration.sql
@@ -1,0 +1,30 @@
+-- CreateTable
+CREATE TABLE "Birthday2026TeamIdentity" (
+    "teamConfigId" INTEGER NOT NULL,
+    "configId" INTEGER NOT NULL,
+    "tucznikUserId" TEXT NOT NULL,
+    "captainUserId" TEXT NOT NULL,
+
+    CONSTRAINT "Birthday2026TeamIdentity_pkey" PRIMARY KEY ("teamConfigId")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Birthday2026TeamIdentity_teamConfigId_configId_key" ON "Birthday2026TeamIdentity"("teamConfigId", "configId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Birthday2026TeamIdentity_configId_tucznikUserId_key" ON "Birthday2026TeamIdentity"("configId", "tucznikUserId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Birthday2026TeamIdentity_configId_captainUserId_key" ON "Birthday2026TeamIdentity"("configId", "captainUserId");
+
+-- CreateIndex
+CREATE INDEX "Birthday2026TeamConfig_configId_idx" ON "Birthday2026TeamConfig"("configId");
+
+-- AddForeignKey
+ALTER TABLE "Birthday2026TeamIdentity" ADD CONSTRAINT "Birthday2026TeamIdentity_teamConfigId_configId_fkey" FOREIGN KEY ("teamConfigId", "configId") REFERENCES "Birthday2026TeamConfig"("id", "configId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Birthday2026TeamIdentity" ADD CONSTRAINT "Birthday2026TeamIdentity_tucznikUserId_fkey" FOREIGN KEY ("tucznikUserId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Birthday2026TeamIdentity" ADD CONSTRAINT "Birthday2026TeamIdentity_captainUserId_fkey" FOREIGN KEY ("captainUserId") REFERENCES "users"("id") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/packages/db/prisma/migrations/20260728120001_backfill_birthday_2026_tucznik_identity/migration.sql
+++ b/packages/db/prisma/migrations/20260728120001_backfill_birthday_2026_tucznik_identity/migration.sql
@@ -1,0 +1,13 @@
+INSERT INTO "Birthday2026TeamIdentity" (
+    "teamConfigId",
+    "configId",
+    "tucznikUserId",
+    "captainUserId"
+)
+SELECT
+    "id",
+    "configId",
+    "captainUserId",
+    "captainUserId"
+FROM "Birthday2026TeamConfig"
+WHERE "captainUserId" IS NOT NULL;

--- a/packages/db/prisma/migrations/20260728120002_remove_birthday_2026_legacy_captain/migration.sql
+++ b/packages/db/prisma/migrations/20260728120002_remove_birthday_2026_legacy_captain/migration.sql
@@ -1,0 +1,14 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `captainUserId` on the `Birthday2026TeamConfig` table. All the data in the column will be lost.
+
+*/
+-- DropForeignKey
+ALTER TABLE "Birthday2026TeamConfig" DROP CONSTRAINT "Birthday2026TeamConfig_captainUserId_fkey";
+
+-- DropIndex
+DROP INDEX "Birthday2026TeamConfig_configId_captainUserId_key";
+
+-- AlterTable
+ALTER TABLE "Birthday2026TeamConfig" DROP COLUMN "captainUserId";

--- a/packages/db/prisma/models/birthday2026.prisma
+++ b/packages/db/prisma/models/birthday2026.prisma
@@ -26,20 +26,34 @@ model Birthday2026EconomyConfig {
 }
 
 model Birthday2026TeamConfig {
-  id            Int     @id @default(autoincrement())
-  configId      Int
-  teamId        Int     @unique
-  roleId        String  @unique
-  color         Int
-  captainUserId String?
+  id       Int    @id @default(autoincrement())
+  configId Int
+  teamId   Int    @unique
+  roleId   String @unique
+  color    Int
 
   config       Birthday2026Config        @relation(fields: [configId], references: [id], onDelete: Cascade)
   team         Team                      @relation(fields: [teamId], references: [id], onDelete: Cascade)
-  captainUser  User?                     @relation("birthday2026Captain", fields: [captainUserId], references: [id])
+  identity     Birthday2026TeamIdentity?
   memberStates Birthday2026MemberState[]
   wallet       Birthday2026TeamWallet?
 
   @@unique([id, configId])
+  @@index([configId])
+}
+
+model Birthday2026TeamIdentity {
+  teamConfigId  Int    @id
+  configId      Int
+  tucznikUserId String
+  captainUserId String
+
+  teamConfig Birthday2026TeamConfig @relation(fields: [teamConfigId, configId], references: [id, configId], onDelete: Cascade)
+  tucznikUser User                   @relation("birthday2026Tucznik", fields: [tucznikUserId], references: [id], onDelete: Restrict)
+  captainUser User                   @relation("birthday2026Captain", fields: [captainUserId], references: [id], onDelete: Restrict)
+
+  @@unique([teamConfigId, configId])
+  @@unique([configId, tucznikUserId])
   @@unique([configId, captainUserId])
 }
 

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -173,7 +173,8 @@ model User {
   shopItemPurchases                 ShopItemPurchase[]
   teamMemberships                   TeamMember[]
   easter2026CaptainOf               Easter2026TeamConfig[]             @relation("easter2026Captain")
-  birthday2026CaptainOf             Birthday2026TeamConfig[]           @relation("birthday2026Captain")
+  birthday2026TucznikOf             Birthday2026TeamIdentity[]         @relation("birthday2026Tucznik")
+  birthday2026CaptainOf             Birthday2026TeamIdentity[]         @relation("birthday2026Captain")
   birthday2026MemberStates          Birthday2026MemberState[]
   birthday2026FeedBatches           Birthday2026FeedBatch[]            @relation("birthday2026FeedOwner")
   birthday2026PersonalTransactions  Birthday2026PersonalTransaction[]  @relation("birthday2026PersonalTransactionOwner")


### PR DESCRIPTION
## Summary

- adds a one-to-one team identity record with required Tucznik and captain IDs
- appoints a Tucznik as the initial captain and preserves the Tucznik across captain replacement
- protects both identities during membership moves, removal, and rebalancing
- provides private staff controls and identity diagnostics

## Why

A team can be unconfigured during setup, but an existing identity must never be partial. This also keeps the public Tucznik stable when operational captain authority changes.

## Validation

- Prisma migrations apply with an empty schema diff
- workspace typecheck passes
- Birthday 2026 database and service tests pass