### PR TITLE
feat(birthday2026): award Pasza for text activity

### DIFF
--- a/apps/bot/src/events/birthday2026/index.ts
+++ b/apps/bot/src/events/birthday2026/index.ts
@@ -1,6 +1,7 @@
 import { Hashira } from "@hashira/core";
 import {
   bold,
+  channelMention,
   PermissionFlagsBits,
   roleMention,
   TimestampStyles,
@@ -11,6 +12,7 @@ import { base } from "../../base";
 import { ensureUserExists } from "../../util/ensureUsersExist";
 import { errorFollowUp } from "../../util/errorFollowUp";
 import { getColor } from "../../util/getColor";
+import { parseChannelMentions } from "../../util/parseChannels";
 import { findBirthday2026Config, upsertBirthday2026Config } from "./configService";
 import {
   type Birthday2026EconomyErrorReason,
@@ -33,6 +35,14 @@ import {
   setBirthday2026Captain,
   setBirthday2026Tucznik,
 } from "./teamService";
+import {
+  awardBirthday2026TextPasza,
+  configureBirthday2026TextEarning,
+  disableBirthday2026TextChannels,
+  enableBirthday2026TextChannels,
+  findBirthday2026DisabledTextChannels,
+  getBirthday2026TextEarningDiagnostics,
+} from "./textEarningService";
 
 const teamErrorMessages = {
   already_in_team: "Ten użytkownik jest już w tej drużynie.",
@@ -99,7 +109,11 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
               return;
             }
 
-            const teams = await findBirthday2026Teams(prisma, itx.guildId);
+            const [teams, disabledTextChannels, textDiagnostics] = await Promise.all([
+              findBirthday2026Teams(prisma, itx.guildId),
+              findBirthday2026DisabledTextChannels(prisma, itx.guildId),
+              getBirthday2026TextEarningDiagnostics(prisma, itx.guildId),
+            ]);
             const now = new Date();
             const configuredTucznicy = teams.filter((team) =>
               Boolean(team.identity?.tucznikUserId),
@@ -129,6 +143,12 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
                 `${bold("Start:")} ${time(config.eventStartAt, TimestampStyles.LongDateTime)}`,
                 `${bold("Koniec:")} ${time(config.eventEndAt, TimestampStyles.LongDateTime)}`,
                 `${bold("Strefa:")} ${config.timezone}`,
+                `${bold("Tekst:")} ${
+                  textDiagnostics
+                    ? `okno=${textDiagnostics.windowSeconds}s, limit=${textDiagnostics.dailyCap}/dzień, wyłączone kanały=${disabledTextChannels?.length ?? 0}`
+                    : "nie skonfigurowano"
+                }`,
+                `${bold("Naliczona Pasza tekstowa:")} ${textDiagnostics?.awardedTransactions ?? 0} — liczniki=${textDiagnostics?.counterTotal ?? 0}, dni użytkowników=${textDiagnostics?.dailyRows ?? 0}, spójne=${textDiagnostics?.reconciled ? "tak" : "NIE"}`,
                 `${bold("Tucznicy:")} ${configuredTucznicy}/${teams.length} — gotowość: ${tucznicyReady ? "tak" : "nie"}`,
                 `${bold("Drużyny:")}`,
                 teamLines.join("\n") || "brak",
@@ -286,6 +306,148 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
               );
             },
           ),
+      )
+      .addCommand("tekst", (command) =>
+        command
+          .setDescription("Skonfiguruj automatyczne zdobywanie Paszy za tekst")
+          .addInteger("okno-minuty", (option) =>
+            option.setDescription("Długość okna aktywności").setMinValue(1),
+          )
+          .addInteger("limit-dzienny", (option) =>
+            option.setDescription("Maksymalna Pasza dziennie").setMinValue(1),
+          )
+          .handle(
+            async (
+              { prisma },
+              { "okno-minuty": windowMinutes, "limit-dzienny": dailyCap },
+              itx,
+            ) => {
+              if (!itx.inCachedGuild()) return;
+              await itx.deferReply({ flags: "Ephemeral" });
+
+              const result = await configureBirthday2026TextEarning(prisma, {
+                guildId: itx.guildId,
+                windowSeconds: windowMinutes * 60,
+                dailyCap,
+              });
+              if (!result.ok) {
+                const messages = {
+                  config_not_found:
+                    "Najpierw skonfiguruj daty eventu komendą `konfiguruj`.",
+                  invalid_daily_cap:
+                    "Limit dzienny musi być dodatnią liczbą całkowitą.",
+                  invalid_window: "Okno aktywności musi być dodatnią liczbą minut.",
+                  text_earning_already_used:
+                    "Nie można zmienić reguł tekstowych po przyznaniu pierwszej Paszy.",
+                };
+                await errorFollowUp(itx, messages[result.reason]);
+                return;
+              }
+
+              await itx.editReply(
+                `Zdobywanie Paszy za tekst: okno ${windowMinutes} min, limit ${dailyCap} na dzień eventowy.`,
+              );
+            },
+          ),
+      )
+      .addCommand("wylacz-kanal-tekst", (command) =>
+        command
+          .setDescription("Wyklucz kanał ze zdobywania Paszy za tekst")
+          .addChannel("kanal", (option) =>
+            option.setDescription("Kanał do wykluczenia"),
+          )
+          .handle(async ({ prisma }, { kanal: channel }, itx) => {
+            if (!itx.inCachedGuild()) return;
+            await itx.deferReply({ flags: "Ephemeral" });
+
+            const result = await disableBirthday2026TextChannel(
+              prisma,
+              itx.guildId,
+              channel.id,
+            );
+            if (!result.ok) {
+              await errorFollowUp(
+                itx,
+                result.reason === "config_not_found"
+                  ? "Event urodzinowy nie jest jeszcze skonfigurowany."
+                  : result.reason === "text_earning_not_configured"
+                    ? "Najpierw skonfiguruj zdobywanie Paszy za tekst."
+                    : "Nieprawidłowy kanał.",
+              );
+              return;
+            }
+
+            await itx.editReply(
+              `${channelMention(result.channelId)} ${
+                result.changed ? "został wykluczony" : "był już wykluczony"
+              } ze zdobywania Paszy.`,
+            );
+          }),
+      )
+      .addCommand("wlacz-kanal-tekst", (command) =>
+        command
+          .setDescription("Przywróć zdobywanie Paszy na kanale")
+          .addChannel("kanal", (option) =>
+            option.setDescription("Kanał do przywrócenia"),
+          )
+          .handle(async ({ prisma }, { kanal: channel }, itx) => {
+            if (!itx.inCachedGuild()) return;
+            await itx.deferReply({ flags: "Ephemeral" });
+
+            const result = await enableBirthday2026TextChannel(
+              prisma,
+              itx.guildId,
+              channel.id,
+            );
+            if (!result.ok) {
+              await errorFollowUp(
+                itx,
+                result.reason === "config_not_found"
+                  ? "Event urodzinowy nie jest jeszcze skonfigurowany."
+                  : result.reason === "text_earning_not_configured"
+                    ? "Najpierw skonfiguruj zdobywanie Paszy za tekst."
+                    : "Nieprawidłowy kanał.",
+              );
+              return;
+            }
+
+            await itx.editReply(
+              `${channelMention(result.channelId)} ${
+                result.changed ? "został przywrócony" : "nie był wykluczony"
+              }.`,
+            );
+          }),
+      )
+      .addCommand("wylaczone-kanaly-tekst", (command) =>
+        command
+          .setDescription("Pokaż kanały bez Paszy za tekst")
+          .handle(async ({ prisma }, _, itx) => {
+            if (!itx.inCachedGuild()) return;
+            await itx.deferReply({ flags: "Ephemeral" });
+
+            const channels = await findBirthday2026DisabledTextChannels(
+              prisma,
+              itx.guildId,
+            );
+            if (!channels) {
+              await errorFollowUp(
+                itx,
+                "Event urodzinowy nie jest jeszcze skonfigurowany.",
+              );
+              return;
+            }
+
+            await itx.editReply(
+              channels.length > 0
+                ? channels
+                    .map(
+                      (channel) =>
+                        `${channelMention(channel.channelId)} (${channel.channelId})`,
+                    )
+                    .join("\n")
+                : "Brak wykluczonych kanałów.",
+            );
+          }),
       ),
   )
   .group("urodziny-ops", (group) =>
@@ -601,4 +763,14 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
             );
           }),
       ),
-  );
+  )
+  .handle("guildMessageCreate", async ({ prisma }, message) => {
+    if (message.author.bot || message.system) return;
+
+    await awardBirthday2026TextPasza(prisma, {
+      guildId: message.guild.id,
+      userId: message.author.id,
+      channelId: message.channel.id,
+      occurredAt: message.createdAt,
+    });
+  });

--- a/apps/bot/src/events/birthday2026/index.ts
+++ b/apps/bot/src/events/birthday2026/index.ts
@@ -353,33 +353,37 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
       .addCommand("wylacz-kanal-tekst", (command) =>
         command
           .setDescription("Wyklucz kanał ze zdobywania Paszy za tekst")
-          .addChannel("kanal", (option) =>
-            option.setDescription("Kanał do wykluczenia"),
+          .addString("kanaly", (option) =>
+            option.setDescription("Kanały do wykluczenia"),
           )
-          .handle(async ({ prisma }, { kanal: channel }, itx) => {
+          .handle(async ({ prisma }, { kanaly: rawChannels }, itx) => {
             if (!itx.inCachedGuild()) return;
             await itx.deferReply({ flags: "Ephemeral" });
 
-            const result = await disableBirthday2026TextChannel(
+            const channelIds = parseChannelMentions(rawChannels);
+            if (channelIds.length === 0) {
+              await errorFollowUp(itx, "Podaj co najmniej jeden kanał.");
+              return;
+            }
+
+            const result = await disableBirthday2026TextChannels(
               prisma,
               itx.guildId,
-              channel.id,
+              channelIds,
             );
             if (!result.ok) {
               await errorFollowUp(
                 itx,
                 result.reason === "config_not_found"
                   ? "Event urodzinowy nie jest jeszcze skonfigurowany."
-                  : result.reason === "text_earning_not_configured"
-                    ? "Najpierw skonfiguruj zdobywanie Paszy za tekst."
-                    : "Nieprawidłowy kanał.",
+                  : "Najpierw skonfiguruj zdobywanie Paszy za tekst.",
               );
               return;
             }
 
             await itx.editReply(
-              `${channelMention(result.channelId)} ${
-                result.changed ? "został wykluczony" : "był już wykluczony"
+              `${result.channelIds.map(channelMention).join(", ")} ${
+                result.changed ? "zostały wykluczone" : "były już wykluczone"
               } ze zdobywania Paszy.`,
             );
           }),
@@ -387,33 +391,37 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
       .addCommand("wlacz-kanal-tekst", (command) =>
         command
           .setDescription("Przywróć zdobywanie Paszy na kanale")
-          .addChannel("kanal", (option) =>
-            option.setDescription("Kanał do przywrócenia"),
+          .addString("kanaly", (option) =>
+            option.setDescription("Kanały do przywrócenia"),
           )
-          .handle(async ({ prisma }, { kanal: channel }, itx) => {
+          .handle(async ({ prisma }, { kanaly: rawChannels }, itx) => {
             if (!itx.inCachedGuild()) return;
             await itx.deferReply({ flags: "Ephemeral" });
 
-            const result = await enableBirthday2026TextChannel(
+            const channelIds = parseChannelMentions(rawChannels);
+            if (channelIds.length === 0) {
+              await errorFollowUp(itx, "Podaj co najmniej jeden kanał.");
+              return;
+            }
+
+            const result = await enableBirthday2026TextChannels(
               prisma,
               itx.guildId,
-              channel.id,
+              channelIds,
             );
             if (!result.ok) {
               await errorFollowUp(
                 itx,
                 result.reason === "config_not_found"
                   ? "Event urodzinowy nie jest jeszcze skonfigurowany."
-                  : result.reason === "text_earning_not_configured"
-                    ? "Najpierw skonfiguruj zdobywanie Paszy za tekst."
-                    : "Nieprawidłowy kanał.",
+                  : "Najpierw skonfiguruj zdobywanie Paszy za tekst.",
               );
               return;
             }
 
             await itx.editReply(
-              `${channelMention(result.channelId)} ${
-                result.changed ? "został przywrócony" : "nie był wykluczony"
+              `${result.channelIds.map(channelMention).join(", ")} ${
+                result.changed ? "zostały przywrócone" : "nie były wykluczone"
               }.`,
             );
           }),

--- a/apps/bot/src/events/birthday2026/textEarningService.ts
+++ b/apps/bot/src/events/birthday2026/textEarningService.ts
@@ -1,0 +1,445 @@
+import type {
+  Birthday2026TextEarningConfig,
+  ExtendedPrismaClient,
+  PrismaTransaction,
+} from "@hashira/db";
+import { nestedTransaction } from "@hashira/db/transaction";
+import { getDefaultWallet } from "../../economy/managers/walletManager";
+import { isUniqueConstraintError } from "../../util/isUniqueConstraintError";
+import { getBirthday2026EventDayIndex, getBirthday2026EventState } from "./eventState";
+
+export type Birthday2026TextEarningErrorReason =
+  | "activity_before_join"
+  | "config_not_found"
+  | "daily_cap_reached"
+  | "disabled_channel"
+  | "economy_not_configured"
+  | "event_not_open"
+  | "invalid_channel"
+  | "invalid_daily_cap"
+  | "invalid_occurred_at"
+  | "invalid_window"
+  | "member_not_found"
+  | "text_earning_already_used"
+  | "text_earning_not_configured";
+
+export type ConfigureBirthday2026TextEarningResult =
+  | { ok: true; config: Birthday2026TextEarningConfig }
+  | {
+      ok: false;
+      reason:
+        | "config_not_found"
+        | "invalid_daily_cap"
+        | "invalid_window"
+        | "text_earning_already_used";
+    };
+
+export const configureBirthday2026TextEarning = async (
+  prisma: ExtendedPrismaClient,
+  input: {
+    guildId: string;
+    windowSeconds: number;
+    dailyCap: number;
+  },
+): Promise<ConfigureBirthday2026TextEarningResult> => {
+  if (!Number.isSafeInteger(input.windowSeconds) || input.windowSeconds <= 0) {
+    return { ok: false, reason: "invalid_window" };
+  }
+  if (!Number.isSafeInteger(input.dailyCap) || input.dailyCap <= 0) {
+    return { ok: false, reason: "invalid_daily_cap" };
+  }
+
+  return prisma.$transaction(async (tx) => {
+    const config = await tx.birthday2026Config.findUnique({
+      where: { guildId: input.guildId },
+      include: { textEarning: true },
+    });
+    if (!config) return { ok: false, reason: "config_not_found" };
+    if (
+      config.textEarning?.windowSeconds === input.windowSeconds &&
+      config.textEarning.dailyCap === input.dailyCap
+    ) {
+      return { ok: true, config: config.textEarning };
+    }
+
+    const existingAward = await tx.birthday2026PersonalTransaction.findFirst({
+      where: { configId: config.id, source: "textActivity" },
+      select: { id: true },
+    });
+    if (existingAward) {
+      return { ok: false, reason: "text_earning_already_used" };
+    }
+
+    return {
+      ok: true,
+      config: await tx.birthday2026TextEarningConfig.upsert({
+        where: { configId: config.id },
+        create: {
+          configId: config.id,
+          windowSeconds: input.windowSeconds,
+          dailyCap: input.dailyCap,
+        },
+        update: {
+          windowSeconds: input.windowSeconds,
+          dailyCap: input.dailyCap,
+        },
+      }),
+    };
+  });
+};
+
+export type Birthday2026DisabledTextChannelResult =
+  | {
+      ok: true;
+      changed: boolean;
+      channelId: string;
+    }
+  | {
+      ok: false;
+      reason: "config_not_found" | "invalid_channel" | "text_earning_not_configured";
+    };
+
+const normalizeChannelId = (channelId: string) => {
+  const normalized = channelId.trim();
+  return normalized.length > 0 ? normalized : null;
+};
+
+export const disableBirthday2026TextChannel = async (
+  prisma: PrismaTransaction,
+  guildId: string,
+  channelId: string,
+): Promise<Birthday2026DisabledTextChannelResult> => {
+  const normalizedChannelId = normalizeChannelId(channelId);
+  if (!normalizedChannelId) return { ok: false, reason: "invalid_channel" };
+
+  const config = await prisma.birthday2026Config.findUnique({
+    where: { guildId },
+    select: { textEarning: { select: { configId: true } } },
+  });
+  if (!config) return { ok: false, reason: "config_not_found" };
+  if (!config.textEarning) {
+    return { ok: false, reason: "text_earning_not_configured" };
+  }
+
+  const result = await prisma.birthday2026DisabledTextChannel.createMany({
+    data: {
+      configId: config.textEarning.configId,
+      channelId: normalizedChannelId,
+    },
+    skipDuplicates: true,
+  });
+  return {
+    ok: true,
+    changed: result.count > 0,
+    channelId: normalizedChannelId,
+  };
+};
+
+export const enableBirthday2026TextChannel = async (
+  prisma: PrismaTransaction,
+  guildId: string,
+  channelId: string,
+): Promise<Birthday2026DisabledTextChannelResult> => {
+  const normalizedChannelId = normalizeChannelId(channelId);
+  if (!normalizedChannelId) return { ok: false, reason: "invalid_channel" };
+
+  const config = await prisma.birthday2026Config.findUnique({
+    where: { guildId },
+    select: { textEarning: { select: { configId: true } } },
+  });
+  if (!config) return { ok: false, reason: "config_not_found" };
+  if (!config.textEarning) {
+    return { ok: false, reason: "text_earning_not_configured" };
+  }
+
+  const result = await prisma.birthday2026DisabledTextChannel.deleteMany({
+    where: {
+      configId: config.textEarning.configId,
+      channelId: normalizedChannelId,
+    },
+  });
+  return {
+    ok: true,
+    changed: result.count > 0,
+    channelId: normalizedChannelId,
+  };
+};
+
+export const findBirthday2026DisabledTextChannels = async (
+  prisma: PrismaTransaction,
+  guildId: string,
+) => {
+  const config = await prisma.birthday2026Config.findUnique({
+    where: { guildId },
+    select: { textEarning: { select: { configId: true } } },
+  });
+  if (!config?.textEarning) return null;
+
+  return prisma.birthday2026DisabledTextChannel.findMany({
+    where: { configId: config.textEarning.configId },
+    orderBy: { channelId: "asc" },
+  });
+};
+
+export const getBirthday2026TextEarningDiagnostics = async (
+  prisma: PrismaTransaction,
+  guildId: string,
+) => {
+  const config = await prisma.birthday2026Config.findUnique({
+    where: { guildId },
+    select: {
+      id: true,
+      textEarning: true,
+    },
+  });
+  if (!config?.textEarning) return null;
+
+  const [dailyCounters, awardedTransactions] = await Promise.all([
+    prisma.birthday2026DailyTextEarning.aggregate({
+      where: { configId: config.id },
+      _count: { _all: true },
+      _sum: { awardedWindows: true },
+    }),
+    prisma.birthday2026PersonalTransaction.count({
+      where: { configId: config.id, source: "textActivity" },
+    }),
+  ]);
+  const counterTotal = dailyCounters._sum.awardedWindows ?? 0;
+
+  return {
+    windowSeconds: config.textEarning.windowSeconds,
+    dailyCap: config.textEarning.dailyCap,
+    awardedTransactions,
+    counterTotal,
+    dailyRows: dailyCounters._count._all,
+    reconciled: counterTotal === awardedTransactions,
+  };
+};
+
+type TextAwardDetails = {
+  eventDayIndex: number;
+  windowIndex: number;
+  dailyAwardedWindows: number;
+  transactionId: number;
+  walletBalance: number;
+};
+
+export type AwardBirthday2026TextPaszaResult =
+  | ({ ok: true; status: "awarded" | "duplicate" } & TextAwardDetails)
+  | { ok: false; reason: Birthday2026TextEarningErrorReason };
+
+const findExistingTextAward = async (
+  prisma: PrismaTransaction,
+  input: {
+    configId: number;
+    userId: string;
+    sourceKey: string;
+    eventDayIndex: number;
+    windowIndex: number;
+  },
+): Promise<Extract<AwardBirthday2026TextPaszaResult, { ok: true }> | null> => {
+  const reference = await prisma.birthday2026PersonalTransaction.findUnique({
+    where: {
+      configId_source_sourceKey: {
+        configId: input.configId,
+        source: "textActivity",
+        sourceKey: input.sourceKey,
+      },
+    },
+    include: {
+      transaction: {
+        include: { wallet: { select: { balance: true } } },
+      },
+    },
+  });
+  if (!reference) return null;
+
+  const dailyState = await prisma.birthday2026DailyTextEarning.findUnique({
+    where: {
+      configId_userId_eventDayIndex: {
+        configId: input.configId,
+        userId: input.userId,
+        eventDayIndex: input.eventDayIndex,
+      },
+    },
+    select: { awardedWindows: true },
+  });
+
+  return {
+    ok: true,
+    status: "duplicate",
+    eventDayIndex: input.eventDayIndex,
+    windowIndex: input.windowIndex,
+    dailyAwardedWindows: dailyState?.awardedWindows ?? 0,
+    transactionId: reference.transactionId,
+    walletBalance: reference.transaction.wallet.balance,
+  };
+};
+
+export const awardBirthday2026TextPasza = async (
+  prisma: ExtendedPrismaClient,
+  input: {
+    guildId: string;
+    userId: string;
+    channelId: string;
+    occurredAt: Date;
+  },
+): Promise<AwardBirthday2026TextPaszaResult> => {
+  if (!Number.isFinite(input.occurredAt.getTime())) {
+    return { ok: false, reason: "invalid_occurred_at" };
+  }
+  const channelId = normalizeChannelId(input.channelId);
+  if (!channelId) return { ok: false, reason: "invalid_channel" };
+
+  const config = await prisma.birthday2026Config.findUnique({
+    where: { guildId: input.guildId },
+    include: {
+      economy: { select: { currencyId: true } },
+      textEarning: {
+        include: {
+          disabledChannels: {
+            where: { channelId },
+            select: { id: true },
+          },
+        },
+      },
+    },
+  });
+  if (!config) return { ok: false, reason: "config_not_found" };
+  if (getBirthday2026EventState(config, input.occurredAt) !== "open") {
+    return { ok: false, reason: "event_not_open" };
+  }
+  if (!config.economy) {
+    return { ok: false, reason: "economy_not_configured" };
+  }
+  if (!config.textEarning) {
+    return { ok: false, reason: "text_earning_not_configured" };
+  }
+  const currencyId = config.economy.currencyId;
+  const textDailyCap = config.textEarning.dailyCap;
+  const textWindowSeconds = config.textEarning.windowSeconds;
+  if (config.textEarning.disabledChannels.length > 0) {
+    return { ok: false, reason: "disabled_channel" };
+  }
+
+  const membership = await prisma.birthday2026MemberState.findUnique({
+    where: {
+      configId_userId: {
+        configId: config.id,
+        userId: input.userId,
+      },
+    },
+    select: { joinedAt: true },
+  });
+  if (!membership) return { ok: false, reason: "member_not_found" };
+  if (input.occurredAt < membership.joinedAt) {
+    return { ok: false, reason: "activity_before_join" };
+  }
+
+  const eventDayIndex = getBirthday2026EventDayIndex(config, input.occurredAt);
+  if (eventDayIndex === null) {
+    return { ok: false, reason: "event_not_open" };
+  }
+  const elapsedSeconds = Math.floor(
+    (input.occurredAt.getTime() - config.eventStartAt.getTime()) / 1000,
+  );
+  const windowIndex = Math.floor(elapsedSeconds / textWindowSeconds);
+  const sourceKey = `${input.userId}:${eventDayIndex}:${windowIndex}`;
+
+  const existing = await findExistingTextAward(prisma, {
+    configId: config.id,
+    userId: input.userId,
+    sourceKey,
+    eventDayIndex,
+    windowIndex,
+  });
+  if (existing) return existing;
+
+  try {
+    const result = await prisma.$transaction(async (tx) => {
+      await tx.birthday2026DailyTextEarning.createMany({
+        data: {
+          configId: config.id,
+          userId: input.userId,
+          eventDayIndex,
+          awardedWindows: 0,
+        },
+        skipDuplicates: true,
+      });
+
+      const counterUpdate = await tx.birthday2026DailyTextEarning.updateMany({
+        where: {
+          configId: config.id,
+          userId: input.userId,
+          eventDayIndex,
+          awardedWindows: { lt: textDailyCap },
+        },
+        data: { awardedWindows: { increment: 1 } },
+      });
+      if (counterUpdate.count === 0) return null;
+
+      const wallet = await getDefaultWallet({
+        prisma: nestedTransaction(tx),
+        guildId: input.guildId,
+        userId: input.userId,
+        currencyId,
+      });
+      const updatedWallet = await tx.wallet.update({
+        where: { id: wallet.id },
+        data: { balance: { increment: 1 } },
+      });
+      const transaction = await tx.transaction.create({
+        data: {
+          walletId: wallet.id,
+          amount: 1,
+          reason: `Birthday 2026 text activity: day ${eventDayIndex}, window ${windowIndex}`,
+          transactionType: "add",
+          entryType: "credit",
+          createdAt: input.occurredAt,
+        },
+      });
+      await tx.birthday2026PersonalTransaction.create({
+        data: {
+          configId: config.id,
+          userId: input.userId,
+          transactionId: transaction.id,
+          source: "textActivity",
+          sourceKey,
+          createdAt: input.occurredAt,
+        },
+      });
+      const dailyState = await tx.birthday2026DailyTextEarning.findUniqueOrThrow({
+        where: {
+          configId_userId_eventDayIndex: {
+            configId: config.id,
+            userId: input.userId,
+            eventDayIndex,
+          },
+        },
+      });
+
+      return {
+        ok: true,
+        status: "awarded",
+        eventDayIndex,
+        windowIndex,
+        dailyAwardedWindows: dailyState.awardedWindows,
+        transactionId: transaction.id,
+        walletBalance: updatedWallet.balance,
+      } satisfies AwardBirthday2026TextPaszaResult;
+    });
+
+    return result ?? { ok: false, reason: "daily_cap_reached" };
+  } catch (error) {
+    if (!isUniqueConstraintError(error)) throw error;
+    const duplicate = await findExistingTextAward(prisma, {
+      configId: config.id,
+      userId: input.userId,
+      sourceKey,
+      eventDayIndex,
+      windowIndex,
+    });
+    if (!duplicate) throw error;
+    return duplicate;
+  }
+};

--- a/apps/bot/src/events/birthday2026/textEarningService.ts
+++ b/apps/bot/src/events/birthday2026/textEarningService.ts
@@ -5,7 +5,7 @@ import {
   type PrismaTransaction,
 } from "@hashira/db";
 import { nestedTransaction } from "@hashira/db/transaction";
-import { getDefaultWallet } from "../../economy/managers/walletManager";
+import { addBalance } from "../../economy/managers/transferManager";
 import { getBirthday2026EventDayIndex, getBirthday2026EventState } from "./eventState";
 
 export type Birthday2026TextEarningErrorReason =
@@ -15,7 +15,6 @@ export type Birthday2026TextEarningErrorReason =
   | "disabled_channel"
   | "economy_not_configured"
   | "event_not_open"
-  | "invalid_channel"
   | "invalid_daily_cap"
   | "invalid_occurred_at"
   | "invalid_window"
@@ -70,99 +69,78 @@ export const configureBirthday2026TextEarning = async (
       return { ok: false, reason: "text_earning_already_used" };
     }
 
-    return {
-      ok: true,
-      config: await tx.birthday2026TextEarningConfig.upsert({
-        where: { configId: config.id },
-        create: {
-          configId: config.id,
-          windowSeconds: input.windowSeconds,
-          dailyCap: input.dailyCap,
-        },
-        update: {
-          windowSeconds: input.windowSeconds,
-          dailyCap: input.dailyCap,
-        },
-      }),
-    };
+    const textEarning = await tx.birthday2026TextEarningConfig.upsert({
+      where: { configId: config.id },
+      create: {
+        configId: config.id,
+        windowSeconds: input.windowSeconds,
+        dailyCap: input.dailyCap,
+      },
+      update: {
+        windowSeconds: input.windowSeconds,
+        dailyCap: input.dailyCap,
+      },
+    });
+
+    return { ok: true, config: textEarning };
   });
 };
 
-export type Birthday2026DisabledTextChannelResult =
-  | {
-      ok: true;
-      changed: boolean;
-      channelId: string;
-    }
-  | {
-      ok: false;
-      reason: "config_not_found" | "invalid_channel" | "text_earning_not_configured";
-    };
-
-const normalizeChannelId = (channelId: string) => {
-  const normalized = channelId.trim();
-  return normalized.length > 0 ? normalized : null;
-};
-
-export const disableBirthday2026TextChannel = async (
+export const disableBirthday2026TextChannels = async (
   prisma: PrismaTransaction,
   guildId: string,
-  channelId: string,
-): Promise<Birthday2026DisabledTextChannelResult> => {
-  const normalizedChannelId = normalizeChannelId(channelId);
-  if (!normalizedChannelId) return { ok: false, reason: "invalid_channel" };
-
+  channelIds: string[],
+) => {
   const config = await prisma.birthday2026Config.findUnique({
     where: { guildId },
     select: { textEarning: { select: { configId: true } } },
   });
-  if (!config) return { ok: false, reason: "config_not_found" };
+  if (!config) return { ok: false, reason: "config_not_found" } as const;
   if (!config.textEarning) {
-    return { ok: false, reason: "text_earning_not_configured" };
+    return { ok: false, reason: "text_earning_not_configured" } as const;
   }
+  const configId = config.textEarning.configId;
 
   const result = await prisma.birthday2026DisabledTextChannel.createMany({
-    data: {
-      configId: config.textEarning.configId,
-      channelId: normalizedChannelId,
-    },
+    data: channelIds.map((channelId) => ({
+      configId,
+      channelId,
+    })),
     skipDuplicates: true,
   });
   return {
     ok: true,
     changed: result.count > 0,
-    channelId: normalizedChannelId,
-  };
+    channelIds,
+  } as const;
 };
 
-export const enableBirthday2026TextChannel = async (
+export const enableBirthday2026TextChannels = async (
   prisma: PrismaTransaction,
   guildId: string,
-  channelId: string,
-): Promise<Birthday2026DisabledTextChannelResult> => {
-  const normalizedChannelId = normalizeChannelId(channelId);
-  if (!normalizedChannelId) return { ok: false, reason: "invalid_channel" };
-
+  channelIds: string[],
+) => {
   const config = await prisma.birthday2026Config.findUnique({
     where: { guildId },
     select: { textEarning: { select: { configId: true } } },
   });
-  if (!config) return { ok: false, reason: "config_not_found" };
+  if (!config) return { ok: false, reason: "config_not_found" } as const;
   if (!config.textEarning) {
-    return { ok: false, reason: "text_earning_not_configured" };
+    return { ok: false, reason: "text_earning_not_configured" } as const;
   }
+  const configId = config.textEarning.configId;
 
   const result = await prisma.birthday2026DisabledTextChannel.deleteMany({
     where: {
-      configId: config.textEarning.configId,
-      channelId: normalizedChannelId,
+      configId,
+      channelId: { in: channelIds },
     },
   });
   return {
     ok: true,
     changed: result.count > 0,
-    channelId: normalizedChannelId,
-  };
+    channelIds,
+  } as const;
 };
 
 export const findBirthday2026DisabledTextChannels = async (
@@ -224,8 +202,13 @@ type TextAwardDetails = {
   walletBalance: number;
 };
 
+type Birthday2026TextAwardedResult = {
+  ok: true;
+  status: "awarded" | "duplicate";
+} & TextAwardDetails;
+
 export type AwardBirthday2026TextPaszaResult =
-  | ({ ok: true; status: "awarded" | "duplicate" } & TextAwardDetails)
+  | Birthday2026TextAwardedResult
   | { ok: false; reason: Birthday2026TextEarningErrorReason };
 
 const findExistingTextAward = async (
@@ -237,7 +220,7 @@ const findExistingTextAward = async (
     eventDayIndex: number;
     windowIndex: number;
   },
-): Promise<Extract<AwardBirthday2026TextPaszaResult, { ok: true }> | null> => {
+): Promise<Birthday2026TextAwardedResult | null> => {
   const reference = await prisma.birthday2026PersonalTransaction.findUnique({
     where: {
       configId_source_sourceKey: {
@@ -288,8 +271,6 @@ export const awardBirthday2026TextPasza = async (
   if (!Number.isFinite(input.occurredAt.getTime())) {
     return { ok: false, reason: "invalid_occurred_at" };
   }
-  const channelId = normalizeChannelId(input.channelId);
-  if (!channelId) return { ok: false, reason: "invalid_channel" };
 
   const config = await prisma.birthday2026Config.findUnique({
     where: { guildId: input.guildId },
@@ -298,7 +279,7 @@ export const awardBirthday2026TextPasza = async (
       textEarning: {
         include: {
           disabledChannels: {
-            where: { channelId },
+            where: { channelId: input.channelId },
             select: { id: true },
           },
         },
@@ -378,25 +359,13 @@ export const awardBirthday2026TextPasza = async (
       });
       if (counterUpdate.count === 0) return null;
 
-      const wallet = await getDefaultWallet({
+      const { transaction, wallet } = await addBalance({
         prisma: nestedTransaction(tx),
         guildId: input.guildId,
-        userId: input.userId,
+        toUserId: input.userId,
+        amount: 1,
+        reason: `Birthday 2026 text activity: day ${eventDayIndex}, window ${windowIndex}`,
         currencyId,
-      });
-      const updatedWallet = await tx.wallet.update({
-        where: { id: wallet.id },
-        data: { balance: { increment: 1 } },
-      });
-      const transaction = await tx.transaction.create({
-        data: {
-          walletId: wallet.id,
-          amount: 1,
-          reason: `Birthday 2026 text activity: day ${eventDayIndex}, window ${windowIndex}`,
-          transactionType: "add",
-          entryType: "credit",
-          createdAt: input.occurredAt,
-        },
       });
       await tx.birthday2026PersonalTransaction.create({
         data: {
@@ -425,8 +394,8 @@ export const awardBirthday2026TextPasza = async (
         windowIndex,
         dailyAwardedWindows: dailyState.awardedWindows,
         transactionId: transaction.id,
-        walletBalance: updatedWallet.balance,
-      } satisfies AwardBirthday2026TextPaszaResult;
+        walletBalance: wallet.balance,
+      } satisfies Birthday2026TextAwardedResult;
     });
 
     return result ?? { ok: false, reason: "daily_cap_reached" };

--- a/apps/bot/src/events/birthday2026/textEarningService.ts
+++ b/apps/bot/src/events/birthday2026/textEarningService.ts
@@ -1,11 +1,11 @@
-import type {
-  Birthday2026TextEarningConfig,
-  ExtendedPrismaClient,
-  PrismaTransaction,
+import {
+  type Birthday2026TextEarningConfig,
+  type ExtendedPrismaClient,
+  isUniqueConstraintError,
+  type PrismaTransaction,
 } from "@hashira/db";
 import { nestedTransaction } from "@hashira/db/transaction";
 import { getDefaultWallet } from "../../economy/managers/walletManager";
-import { isUniqueConstraintError } from "../../util/isUniqueConstraintError";
 import { getBirthday2026EventDayIndex, getBirthday2026EventState } from "./eventState";
 
 export type Birthday2026TextEarningErrorReason =

--- a/apps/bot/test/birthday2026/textEarningService.database.test.ts
+++ b/apps/bot/test/birthday2026/textEarningService.database.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, it } from "bun:test";
-import { PrismaClient } from "@hashira/prisma-client";
+import { PrismaClient } from "@hashira/db";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { upsertBirthday2026Config } from "../../src/events/birthday2026/configService";
 import { setupBirthday2026Economy } from "../../src/events/birthday2026/economyService";

--- a/apps/bot/test/birthday2026/textEarningService.database.test.ts
+++ b/apps/bot/test/birthday2026/textEarningService.database.test.ts
@@ -1,0 +1,420 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import { PrismaClient } from "@hashira/prisma-client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { upsertBirthday2026Config } from "../../src/events/birthday2026/configService";
+import { setupBirthday2026Economy } from "../../src/events/birthday2026/economyService";
+import {
+  assignBirthday2026Member,
+  createBirthday2026Team,
+} from "../../src/events/birthday2026/teamService";
+import {
+  awardBirthday2026TextPasza,
+  configureBirthday2026TextEarning,
+  disableBirthday2026TextChannel,
+  enableBirthday2026TextChannel,
+  findBirthday2026DisabledTextChannels,
+  getBirthday2026TextEarningDiagnostics,
+} from "../../src/events/birthday2026/textEarningService";
+
+const connectionString = process.env.DATABASE_TEST_URL;
+const databaseTests = describe.skipIf(!connectionString);
+const prisma = connectionString
+  ? new PrismaClient({
+      adapter: new PrismaPg({ connectionString }),
+    })
+  : null;
+
+const guildIds: string[] = [];
+const userIds: string[] = [];
+const currencyIds: number[] = [];
+
+const createFixture = async (dailyCap = 24, windowSeconds = 300) => {
+  if (!prisma) throw new Error("DATABASE_TEST_URL is required");
+  const suffix = crypto.randomUUID();
+  const guildId = `birthday-text-guild-${suffix}`;
+  const actorUserId = `birthday-text-actor-${suffix}`;
+  const memberUserId = `birthday-text-member-${suffix}`;
+  const nonMemberUserId = `birthday-text-non-member-${suffix}`;
+  guildIds.push(guildId);
+  userIds.push(actorUserId, memberUserId, nonMemberUserId);
+
+  await prisma.guild.create({ data: { id: guildId } });
+  await prisma.user.createMany({
+    data: [{ id: actorUserId }, { id: memberUserId }, { id: nonMemberUserId }],
+  });
+
+  const configResult = await upsertBirthday2026Config(prisma, {
+    guildId,
+    eventStartAt: new Date("2026-08-01T18:00:00Z"),
+    eventEndAt: new Date("2026-08-08T18:00:00Z"),
+    timezone: "Europe/Warsaw",
+    visible: true,
+    enabled: true,
+  });
+  if (!configResult.ok) throw new Error(configResult.reason);
+
+  const teamResult = await createBirthday2026Team(prisma, {
+    guildId,
+    name: `Team ${suffix}`,
+    roleId: `role-${suffix}`,
+    color: 0xff8800,
+  });
+  if (!teamResult.ok) throw new Error(teamResult.reason);
+
+  const assignment = await assignBirthday2026Member(prisma, {
+    guildId,
+    teamConfigId: teamResult.team.id,
+    userId: memberUserId,
+  });
+  if (!assignment.ok) throw new Error(assignment.reason);
+
+  const economy = await setupBirthday2026Economy(prisma, {
+    guildId,
+    currencyName: `Pasza ${suffix}`,
+    currencySymbol: `P${suffix.slice(0, 6)}`,
+    digestionDelaySeconds: 14_400,
+    createdByUserId: actorUserId,
+  });
+  if (!economy.ok) throw new Error(economy.reason);
+  currencyIds.push(economy.currencyId);
+
+  const textConfig = await configureBirthday2026TextEarning(prisma, {
+    guildId,
+    windowSeconds,
+    dailyCap,
+  });
+  if (!textConfig.ok) throw new Error(textConfig.reason);
+
+  return {
+    config: configResult.config,
+    currencyId: economy.currencyId,
+    guildId,
+    memberUserId,
+    nonMemberUserId,
+    suffix,
+  };
+};
+
+databaseTests("Birthday 2026 text earning", () => {
+  afterAll(async () => {
+    if (!prisma) return;
+
+    await prisma.birthday2026Config.deleteMany({
+      where: { guildId: { in: guildIds } },
+    });
+    await prisma.transaction.deleteMany({
+      where: { wallet: { currencyId: { in: currencyIds } } },
+    });
+    await prisma.wallet.deleteMany({
+      where: { currencyId: { in: currencyIds } },
+    });
+    await prisma.currency.deleteMany({ where: { id: { in: currencyIds } } });
+    await prisma.team.deleteMany({ where: { guildId: { in: guildIds } } });
+    await prisma.guild.deleteMany({ where: { id: { in: guildIds } } });
+    await prisma.user.deleteMany({ where: { id: { in: userIds } } });
+    await prisma.$disconnect();
+  });
+
+  it("configures text earning and manages disabled channels idempotently", async () => {
+    if (!prisma) throw new Error("DATABASE_TEST_URL is required");
+    const fixture = await createFixture();
+
+    expect(
+      await configureBirthday2026TextEarning(prisma, {
+        guildId: fixture.guildId,
+        windowSeconds: 0,
+        dailyCap: 24,
+      }),
+    ).toEqual({ ok: false, reason: "invalid_window" });
+    expect(
+      await configureBirthday2026TextEarning(prisma, {
+        guildId: fixture.guildId,
+        windowSeconds: 300,
+        dailyCap: 0,
+      }),
+    ).toEqual({ ok: false, reason: "invalid_daily_cap" });
+    expect(
+      await prisma.birthday2026TextEarningConfig.findUnique({
+        where: { configId: fixture.config.id },
+      }),
+    ).toEqual({
+      configId: fixture.config.id,
+      windowSeconds: 300,
+      dailyCap: 24,
+    });
+
+    expect(
+      await disableBirthday2026TextChannel(prisma, fixture.guildId, "disabled-channel"),
+    ).toEqual({
+      ok: true,
+      changed: true,
+      channelId: "disabled-channel",
+    });
+    expect(
+      await disableBirthday2026TextChannel(prisma, fixture.guildId, "disabled-channel"),
+    ).toEqual({
+      ok: true,
+      changed: false,
+      channelId: "disabled-channel",
+    });
+    expect(await findBirthday2026DisabledTextChannels(prisma, fixture.guildId)).toEqual(
+      [expect.objectContaining({ channelId: "disabled-channel" })],
+    );
+    expect(
+      await enableBirthday2026TextChannel(prisma, fixture.guildId, "disabled-channel"),
+    ).toEqual({
+      ok: true,
+      changed: true,
+      channelId: "disabled-channel",
+    });
+    expect(await findBirthday2026DisabledTextChannels(prisma, fixture.guildId)).toEqual(
+      [],
+    );
+  });
+
+  it("awards one Pasza per fixed window exactly once", async () => {
+    if (!prisma) throw new Error("DATABASE_TEST_URL is required");
+    const fixture = await createFixture();
+    const firstWindow = {
+      guildId: fixture.guildId,
+      userId: fixture.memberUserId,
+      channelId: "general",
+      occurredAt: new Date("2026-08-01T18:00:30Z"),
+    };
+
+    expect(await awardBirthday2026TextPasza(prisma, firstWindow)).toMatchObject({
+      ok: true,
+      status: "awarded",
+      eventDayIndex: 0,
+      windowIndex: 0,
+      dailyAwardedWindows: 1,
+      walletBalance: 1,
+    });
+    expect(await awardBirthday2026TextPasza(prisma, firstWindow)).toMatchObject({
+      ok: true,
+      status: "duplicate",
+      eventDayIndex: 0,
+      windowIndex: 0,
+      walletBalance: 1,
+    });
+    expect(
+      await awardBirthday2026TextPasza(prisma, {
+        ...firstWindow,
+        occurredAt: new Date("2026-08-01T18:04:59Z"),
+      }),
+    ).toMatchObject({
+      ok: true,
+      status: "duplicate",
+      windowIndex: 0,
+      walletBalance: 1,
+    });
+    expect(
+      await awardBirthday2026TextPasza(prisma, {
+        ...firstWindow,
+        occurredAt: new Date("2026-08-01T18:05:00Z"),
+      }),
+    ).toMatchObject({
+      ok: true,
+      status: "awarded",
+      windowIndex: 1,
+      dailyAwardedWindows: 2,
+      walletBalance: 2,
+    });
+
+    expect(
+      await prisma.birthday2026PersonalTransaction.count({
+        where: { configId: fixture.config.id, source: "textActivity" },
+      }),
+    ).toBe(2);
+    expect(
+      await getBirthday2026TextEarningDiagnostics(prisma, fixture.guildId),
+    ).toEqual({
+      windowSeconds: 300,
+      dailyCap: 24,
+      awardedTransactions: 2,
+      counterTotal: 2,
+      dailyRows: 1,
+      reconciled: true,
+    });
+    expect(
+      await configureBirthday2026TextEarning(prisma, {
+        guildId: fixture.guildId,
+        windowSeconds: 600,
+        dailyCap: 24,
+      }),
+    ).toEqual({ ok: false, reason: "text_earning_already_used" });
+  });
+
+  it("enforces the daily cap atomically across concurrent windows", async () => {
+    if (!prisma) throw new Error("DATABASE_TEST_URL is required");
+    const fixture = await createFixture(2);
+
+    const results = await Promise.all(
+      Array.from({ length: 10 }, (_, index) =>
+        awardBirthday2026TextPasza(prisma, {
+          guildId: fixture.guildId,
+          userId: fixture.memberUserId,
+          channelId: "general",
+          occurredAt: new Date(
+            new Date("2026-08-01T18:00:00Z").getTime() + index * 300_000,
+          ),
+        }),
+      ),
+    );
+
+    expect(
+      results.filter((result) => result.ok && result.status === "awarded"),
+    ).toHaveLength(2);
+    expect(
+      results.filter((result) => !result.ok && result.reason === "daily_cap_reached"),
+    ).toHaveLength(8);
+
+    const dailyState = await prisma.birthday2026DailyTextEarning.findUniqueOrThrow({
+      where: {
+        configId_userId_eventDayIndex: {
+          configId: fixture.config.id,
+          userId: fixture.memberUserId,
+          eventDayIndex: 0,
+        },
+      },
+    });
+    const wallet = await prisma.wallet.findFirstOrThrow({
+      where: {
+        userId: fixture.memberUserId,
+        currencyId: fixture.currencyId,
+      },
+    });
+    expect(dailyState.awardedWindows).toBe(2);
+    expect(wallet.balance).toBe(2);
+    expect(
+      await prisma.birthday2026PersonalTransaction.count({
+        where: { configId: fixture.config.id, source: "textActivity" },
+      }),
+    ).toBe(2);
+  });
+
+  it("awards a concurrently retried window exactly once", async () => {
+    if (!prisma) throw new Error("DATABASE_TEST_URL is required");
+    const fixture = await createFixture();
+    const input = {
+      guildId: fixture.guildId,
+      userId: fixture.memberUserId,
+      channelId: "general",
+      occurredAt: new Date("2026-08-01T18:00:00Z"),
+    };
+
+    const results = await Promise.all(
+      Array.from({ length: 10 }, () => awardBirthday2026TextPasza(prisma, input)),
+    );
+
+    expect(
+      results.filter((result) => result.ok && result.status === "awarded"),
+    ).toHaveLength(1);
+    expect(
+      results.filter((result) => result.ok && result.status === "duplicate"),
+    ).toHaveLength(9);
+
+    const dailyState = await prisma.birthday2026DailyTextEarning.findUniqueOrThrow({
+      where: {
+        configId_userId_eventDayIndex: {
+          configId: fixture.config.id,
+          userId: fixture.memberUserId,
+          eventDayIndex: 0,
+        },
+      },
+    });
+    const wallet = await prisma.wallet.findFirstOrThrow({
+      where: {
+        userId: fixture.memberUserId,
+        currencyId: fixture.currencyId,
+      },
+    });
+    expect(dailyState.awardedWindows).toBe(1);
+    expect(wallet.balance).toBe(1);
+    expect(
+      await prisma.birthday2026PersonalTransaction.count({
+        where: { configId: fixture.config.id, source: "textActivity" },
+      }),
+    ).toBe(1);
+  });
+
+  it("enforces event, membership, join-time, and disabled-channel eligibility", async () => {
+    if (!prisma) throw new Error("DATABASE_TEST_URL is required");
+    const fixture = await createFixture();
+    const input = {
+      guildId: fixture.guildId,
+      userId: fixture.memberUserId,
+      channelId: "general",
+      occurredAt: new Date("2026-08-01T18:00:00Z"),
+    };
+
+    expect(
+      await awardBirthday2026TextPasza(prisma, {
+        ...input,
+        occurredAt: new Date("2026-08-01T17:59:59Z"),
+      }),
+    ).toEqual({ ok: false, reason: "event_not_open" });
+    expect(
+      await awardBirthday2026TextPasza(prisma, {
+        ...input,
+        userId: fixture.nonMemberUserId,
+      }),
+    ).toEqual({ ok: false, reason: "member_not_found" });
+
+    await disableBirthday2026TextChannel(prisma, fixture.guildId, input.channelId);
+    expect(await awardBirthday2026TextPasza(prisma, input)).toEqual({
+      ok: false,
+      reason: "disabled_channel",
+    });
+    await enableBirthday2026TextChannel(prisma, fixture.guildId, input.channelId);
+
+    await prisma.birthday2026MemberState.update({
+      where: {
+        configId_userId: {
+          configId: fixture.config.id,
+          userId: fixture.memberUserId,
+        },
+      },
+      data: { joinedAt: new Date("2026-08-01T19:00:00Z") },
+    });
+    expect(await awardBirthday2026TextPasza(prisma, input)).toEqual({
+      ok: false,
+      reason: "activity_before_join",
+    });
+  });
+
+  it("resets the cap on the next event-anchored day", async () => {
+    if (!prisma) throw new Error("DATABASE_TEST_URL is required");
+    const fixture = await createFixture(1);
+    const baseInput = {
+      guildId: fixture.guildId,
+      userId: fixture.memberUserId,
+      channelId: "general",
+    };
+
+    expect(
+      await awardBirthday2026TextPasza(prisma, {
+        ...baseInput,
+        occurredAt: new Date("2026-08-01T18:00:00Z"),
+      }),
+    ).toMatchObject({ ok: true, status: "awarded", eventDayIndex: 0 });
+    expect(
+      await awardBirthday2026TextPasza(prisma, {
+        ...baseInput,
+        occurredAt: new Date("2026-08-01T18:05:00Z"),
+      }),
+    ).toEqual({ ok: false, reason: "daily_cap_reached" });
+    expect(
+      await awardBirthday2026TextPasza(prisma, {
+        ...baseInput,
+        occurredAt: new Date("2026-08-02T18:00:00Z"),
+      }),
+    ).toMatchObject({
+      ok: true,
+      status: "awarded",
+      eventDayIndex: 1,
+      dailyAwardedWindows: 1,
+      walletBalance: 2,
+    });
+  });
+});

--- a/apps/bot/test/birthday2026/textEarningService.database.test.ts
+++ b/apps/bot/test/birthday2026/textEarningService.database.test.ts
@@ -10,8 +10,8 @@ import {
 import {
   awardBirthday2026TextPasza,
   configureBirthday2026TextEarning,
-  disableBirthday2026TextChannel,
-  enableBirthday2026TextChannel,
+  disableBirthday2026TextChannels,
+  enableBirthday2026TextChannels,
   findBirthday2026DisabledTextChannels,
   getBirthday2026TextEarningDiagnostics,
 } from "../../src/events/birthday2026/textEarningService";
@@ -67,6 +67,15 @@ const createFixture = async (dailyCap = 24, windowSeconds = 300) => {
     userId: memberUserId,
   });
   if (!assignment.ok) throw new Error(assignment.reason);
+  await prisma.birthday2026MemberState.update({
+    where: {
+      configId_userId: {
+        configId: configResult.config.id,
+        userId: memberUserId,
+      },
+    },
+    data: { joinedAt: new Date("2026-08-01T18:00:00Z") },
+  });
 
   const economy = await setupBirthday2026Economy(prisma, {
     guildId,
@@ -144,28 +153,40 @@ databaseTests("Birthday 2026 text earning", () => {
     });
 
     expect(
-      await disableBirthday2026TextChannel(prisma, fixture.guildId, "disabled-channel"),
+      await disableBirthday2026TextChannels(prisma, fixture.guildId, [
+        "disabled-channel",
+        "another-disabled-channel",
+      ]),
     ).toEqual({
       ok: true,
       changed: true,
-      channelId: "disabled-channel",
+      channelIds: ["disabled-channel", "another-disabled-channel"],
     });
     expect(
-      await disableBirthday2026TextChannel(prisma, fixture.guildId, "disabled-channel"),
+      await disableBirthday2026TextChannels(prisma, fixture.guildId, [
+        "disabled-channel",
+        "another-disabled-channel",
+      ]),
     ).toEqual({
       ok: true,
       changed: false,
-      channelId: "disabled-channel",
+      channelIds: ["disabled-channel", "another-disabled-channel"],
     });
     expect(await findBirthday2026DisabledTextChannels(prisma, fixture.guildId)).toEqual(
-      [expect.objectContaining({ channelId: "disabled-channel" })],
+      expect.arrayContaining([
+        expect.objectContaining({ channelId: "disabled-channel" }),
+        expect.objectContaining({ channelId: "another-disabled-channel" }),
+      ]),
     );
     expect(
-      await enableBirthday2026TextChannel(prisma, fixture.guildId, "disabled-channel"),
+      await enableBirthday2026TextChannels(prisma, fixture.guildId, [
+        "disabled-channel",
+        "another-disabled-channel",
+      ]),
     ).toEqual({
       ok: true,
       changed: true,
-      channelId: "disabled-channel",
+      channelIds: ["disabled-channel", "another-disabled-channel"],
     });
     expect(await findBirthday2026DisabledTextChannels(prisma, fixture.guildId)).toEqual(
       [],
@@ -361,12 +382,12 @@ databaseTests("Birthday 2026 text earning", () => {
       }),
     ).toEqual({ ok: false, reason: "member_not_found" });
 
-    await disableBirthday2026TextChannel(prisma, fixture.guildId, input.channelId);
+    await disableBirthday2026TextChannels(prisma, fixture.guildId, [input.channelId]);
     expect(await awardBirthday2026TextPasza(prisma, input)).toEqual({
       ok: false,
       reason: "disabled_channel",
     });
-    await enableBirthday2026TextChannel(prisma, fixture.guildId, input.channelId);
+    await enableBirthday2026TextChannels(prisma, fixture.guildId, [input.channelId]);
 
     await prisma.birthday2026MemberState.update({
       where: {

--- a/packages/db/prisma/migrations/20260728130000_add_birthday_2026_text_earning/migration.sql
+++ b/packages/db/prisma/migrations/20260728130000_add_birthday_2026_text_earning/migration.sql
@@ -1,0 +1,48 @@
+-- AlterEnum
+ALTER TYPE "Birthday2026PersonalTransactionSource" ADD VALUE 'textActivity';
+
+-- CreateTable
+CREATE TABLE "Birthday2026TextEarningConfig" (
+    "configId" INTEGER NOT NULL,
+    "windowSeconds" INTEGER NOT NULL,
+    "dailyCap" INTEGER NOT NULL,
+
+    CONSTRAINT "Birthday2026TextEarningConfig_pkey" PRIMARY KEY ("configId")
+);
+
+-- CreateTable
+CREATE TABLE "Birthday2026DisabledTextChannel" (
+    "id" SERIAL NOT NULL,
+    "configId" INTEGER NOT NULL,
+    "channelId" TEXT NOT NULL,
+
+    CONSTRAINT "Birthday2026DisabledTextChannel_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "Birthday2026DailyTextEarning" (
+    "configId" INTEGER NOT NULL,
+    "userId" TEXT NOT NULL,
+    "eventDayIndex" INTEGER NOT NULL,
+    "awardedWindows" INTEGER NOT NULL,
+
+    CONSTRAINT "Birthday2026DailyTextEarning_pkey" PRIMARY KEY ("configId","userId","eventDayIndex")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Birthday2026DisabledTextChannel_configId_channelId_key" ON "Birthday2026DisabledTextChannel"("configId", "channelId");
+
+-- CreateIndex
+CREATE INDEX "Birthday2026DailyTextEarning_userId_idx" ON "Birthday2026DailyTextEarning"("userId");
+
+-- AddForeignKey
+ALTER TABLE "Birthday2026TextEarningConfig" ADD CONSTRAINT "Birthday2026TextEarningConfig_configId_fkey" FOREIGN KEY ("configId") REFERENCES "Birthday2026Config"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Birthday2026DisabledTextChannel" ADD CONSTRAINT "Birthday2026DisabledTextChannel_configId_fkey" FOREIGN KEY ("configId") REFERENCES "Birthday2026TextEarningConfig"("configId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Birthday2026DailyTextEarning" ADD CONSTRAINT "Birthday2026DailyTextEarning_configId_fkey" FOREIGN KEY ("configId") REFERENCES "Birthday2026TextEarningConfig"("configId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Birthday2026DailyTextEarning" ADD CONSTRAINT "Birthday2026DailyTextEarning_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/migrations/20260728130001_add_birthday_2026_text_earning_checks/migration.sql
+++ b/packages/db/prisma/migrations/20260728130001_add_birthday_2026_text_earning_checks/migration.sql
@@ -1,0 +1,13 @@
+-- Manual migration based on 20260728130000_add_birthday_2026_text_earning.
+
+ALTER TABLE "Birthday2026TextEarningConfig"
+  ADD CONSTRAINT "Birthday2026TextEarningConfig_window_seconds_valid"
+  CHECK ("windowSeconds" > 0),
+  ADD CONSTRAINT "Birthday2026TextEarningConfig_daily_cap_valid"
+  CHECK ("dailyCap" > 0);
+
+ALTER TABLE "Birthday2026DailyTextEarning"
+  ADD CONSTRAINT "Birthday2026DailyTextEarning_event_day_valid"
+  CHECK ("eventDayIndex" >= 0),
+  ADD CONSTRAINT "Birthday2026DailyTextEarning_awarded_windows_valid"
+  CHECK ("awardedWindows" >= 0);

--- a/packages/db/prisma/models/birthday2026.prisma
+++ b/packages/db/prisma/models/birthday2026.prisma
@@ -11,6 +11,7 @@ model Birthday2026Config {
 
   guild                Guild                             @relation(fields: [guildId], references: [id], onDelete: Cascade)
   economy              Birthday2026EconomyConfig?
+  textEarning          Birthday2026TextEarningConfig?
   teams                Birthday2026TeamConfig[]
   feedBatches          Birthday2026FeedBatch[]
   personalTransactions Birthday2026PersonalTransaction[]
@@ -23,6 +24,16 @@ model Birthday2026EconomyConfig {
 
   config   Birthday2026Config @relation(fields: [configId], references: [id], onDelete: Cascade)
   currency Currency           @relation(fields: [currencyId], references: [id], onDelete: Restrict)
+}
+
+model Birthday2026TextEarningConfig {
+  configId      Int @id
+  windowSeconds Int
+  dailyCap      Int
+
+  config           Birthday2026Config                @relation(fields: [configId], references: [id], onDelete: Cascade)
+  disabledChannels Birthday2026DisabledTextChannel[]
+  dailyStates      Birthday2026DailyTextEarning[]
 }
 
 model Birthday2026TeamConfig {
@@ -69,6 +80,29 @@ model Birthday2026MemberState {
 
   @@unique([configId, userId])
   @@index([teamConfigId, configId])
+  @@index([userId])
+}
+
+model Birthday2026DisabledTextChannel {
+  id        Int    @id @default(autoincrement())
+  configId  Int
+  channelId String
+
+  config Birthday2026TextEarningConfig @relation(fields: [configId], references: [configId], onDelete: Cascade)
+
+  @@unique([configId, channelId])
+}
+
+model Birthday2026DailyTextEarning {
+  configId       Int
+  userId         String
+  eventDayIndex  Int
+  awardedWindows Int
+
+  config Birthday2026TextEarningConfig @relation(fields: [configId], references: [configId], onDelete: Cascade)
+  user   User                          @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@id([configId, userId, eventDayIndex])
   @@index([userId])
 }
 
@@ -136,6 +170,7 @@ model Birthday2026FeedBatch {
 enum Birthday2026PersonalTransactionSource {
   staffGrant
   feed
+  textActivity
 }
 
 enum Birthday2026TeamWalletTransactionSource {

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -176,6 +176,7 @@ model User {
   birthday2026TucznikOf             Birthday2026TeamIdentity[]         @relation("birthday2026Tucznik")
   birthday2026CaptainOf             Birthday2026TeamIdentity[]         @relation("birthday2026Captain")
   birthday2026MemberStates          Birthday2026MemberState[]
+  birthday2026DailyTextEarnings     Birthday2026DailyTextEarning[]
   birthday2026FeedBatches           Birthday2026FeedBatch[]            @relation("birthday2026FeedOwner")
   birthday2026PersonalTransactions  Birthday2026PersonalTransaction[]  @relation("birthday2026PersonalTransactionOwner")
   createdBirthday2026Transactions   Birthday2026PersonalTransaction[]  @relation("birthday2026PersonalTransactionCreator")


### PR DESCRIPTION
## Summary

- adds required text-earning configuration as an optional one-to-one feature record
- awards one Pasza per fixed qualifying activity window with an atomic daily cap
- handles retries and concurrent messages idempotently
- supports disabled channels, eligibility checks, staff configuration, and reconciliation diagnostics

## Why

This implements the first calibrated passive Pasza source without allowing half-configured text settings or duplicate rewards.

## Validation

- all 53 migrations apply on a clean database with an empty Prisma diff
- workspace typecheck passes
- 392 tests pass with 1 existing skip