### PR TITLE
feat(birthday2026): add public player loop

### DIFF
--- a/apps/bot/src/events/birthday2026/economyService.ts
+++ b/apps/bot/src/events/birthday2026/economyService.ts
@@ -258,10 +258,20 @@ export const grantBirthday2026Pasza = async (
   });
 };
 
-type ScheduleDigestion = (
+export type ScheduleBirthday2026Digestion = (
   tx: PrismaTransaction,
   batch: Pick<Birthday2026FeedBatch, "digestAt" | "id">,
 ) => Promise<void>;
+
+export type FeedBirthday2026PigInput = {
+  guildId: string;
+  userId: string;
+  amount: number;
+  sourceKey: string;
+  acceptedAt: Date;
+  reason: string;
+  scheduleDigestion: ScheduleBirthday2026Digestion;
+};
 
 export type FeedBirthday2026PigResult =
   | {
@@ -303,15 +313,7 @@ const findFeedResult = async (
 
 export const feedBirthday2026Pig = async (
   prisma: ExtendedPrismaClient,
-  input: {
-    guildId: string;
-    userId: string;
-    amount: number;
-    sourceKey: string;
-    acceptedAt: Date;
-    reason: string;
-    scheduleDigestion: ScheduleDigestion;
-  },
+  input: FeedBirthday2026PigInput,
 ): Promise<FeedBirthday2026PigResult> => {
   const config = await prisma.birthday2026Config.findUnique({
     where: { guildId: input.guildId },

--- a/apps/bot/src/events/birthday2026/eventState.ts
+++ b/apps/bot/src/events/birthday2026/eventState.ts
@@ -2,10 +2,18 @@ import type { Birthday2026Config } from "@hashira/db";
 
 const MILLISECONDS_PER_EVENT_DAY = 24 * 60 * 60 * 1000;
 
+export type Birthday2026EventState =
+  | "not_configured"
+  | "hidden"
+  | "disabled"
+  | "not_started"
+  | "open"
+  | "finished";
+
 export const getBirthday2026EventState = (
   config: Birthday2026Config | null,
   now: Date,
-) => {
+): Birthday2026EventState => {
   if (!config) return "not_configured";
   if (!config.visible) return "hidden";
   if (!config.enabled) return "disabled";

--- a/apps/bot/src/events/birthday2026/eventState.ts
+++ b/apps/bot/src/events/birthday2026/eventState.ts
@@ -13,13 +13,13 @@ export type Birthday2026EventState =
 export const getBirthday2026EventState = (
   config: Birthday2026Config | null,
   now: Date,
-): Birthday2026EventState => {
-  if (!config) return "not_configured";
-  if (!config.visible) return "hidden";
-  if (!config.enabled) return "disabled";
-  if (now < config.eventStartAt) return "not_started";
-  if (now >= config.eventEndAt) return "finished";
-  return "open";
+) => {
+  if (!config) return "not_configured" as const;
+  if (!config.visible) return "hidden" as const;
+  if (!config.enabled) return "disabled" as const;
+  if (now < config.eventStartAt) return "not_started" as const;
+  if (now >= config.eventEndAt) return "finished" as const;
+  return "open" as const;
 };
 
 export const getBirthday2026RegistrationState = (

--- a/apps/bot/src/events/birthday2026/index.ts
+++ b/apps/bot/src/events/birthday2026/index.ts
@@ -40,7 +40,7 @@ import {
   buildBirthday2026RankingView,
   buildBirthday2026StatusView,
 } from "./playerView";
-import { parseBirthday2026Instant, parseBirthday2026TeamColor } from "./staffInput";
+import { parseBirthday2026Instant } from "./staffInput";
 import {
   assignBirthday2026Member,
   createBirthday2026Team,

--- a/apps/bot/src/events/birthday2026/index.ts
+++ b/apps/bot/src/events/birthday2026/index.ts
@@ -1,9 +1,11 @@
 import { Hashira } from "@hashira/core";
+import type { PrismaTransaction } from "@hashira/db";
 import { render } from "@hashira/jsx";
 import {
   bold,
   channelMention,
   PermissionFlagsBits,
+  type RepliableInteraction,
   roleMention,
   TimestampStyles,
   time,
@@ -27,8 +29,8 @@ import {
   getBirthday2026RegistrationState,
 } from "./eventState";
 import {
+  type Birthday2026PlayerFeedErrorReason,
   type Birthday2026PublicErrorReason,
-  type FeedBirthday2026PlayerResult,
   feedBirthday2026Player,
   getBirthday2026PlayerSnapshot,
 } from "./playerService";
@@ -83,7 +85,7 @@ const teamErrorMessages = {
   tucznik_not_member: "Tucznik musi należeć do wskazanej drużyny.",
 };
 
-const economyErrorMessages: Record<Birthday2026EconomyErrorReason, string> = {
+const economyErrorMessages = {
   config_not_found: "Event urodzinowy nie jest jeszcze skonfigurowany.",
   currency_conflict: "Nazwa albo symbol waluty są już używane na tym serwerze.",
   economy_already_configured: "Ekonomia jest już skonfigurowana z innymi wartościami.",
@@ -93,32 +95,27 @@ const economyErrorMessages: Record<Birthday2026EconomyErrorReason, string> = {
   invalid_digestion_delay: "Czas trawienia musi być nieujemną liczbą sekund.",
   member_not_found: "Ten użytkownik nie należy do eventu.",
   team_wallet_not_found: "Drużyna nie ma poprawnie skonfigurowanego portfela.",
-};
+} satisfies Record<Birthday2026EconomyErrorReason, string>;
 
-const publicErrorMessages: Record<Birthday2026PublicErrorReason, string> = {
+const publicErrorMessages = {
   economy_not_configured: "Ekonomia eventu nie jest jeszcze gotowa.",
   event_not_available: "Event nie jest teraz dostępny.",
   teams_not_ready: "Drużyny i ich Tucznicy nie są jeszcze gotowi.",
-};
+} satisfies Record<Birthday2026PublicErrorReason, string>;
 
-type Birthday2026PlayerFeedErrorReason = Extract<
-  FeedBirthday2026PlayerResult,
-  { ok: false }
->["reason"];
-
-const playerFeedErrorMessages: Record<Birthday2026PlayerFeedErrorReason, string> = {
+const playerFeedErrorMessages = {
   ...economyErrorMessages,
   event_not_available: "Event nie jest teraz dostępny.",
   event_not_open: "Karmienie jest dostępne tylko podczas trwania eventu.",
   teams_not_ready: "Drużyny i ich Tucznicy nie są jeszcze gotowi.",
-};
+} satisfies Record<Birthday2026PlayerFeedErrorReason, string>;
 
 const getPlayerSnapshotOrReply = async (
-  prisma: Parameters<typeof getBirthday2026PlayerSnapshot>[0],
+  prisma: PrismaTransaction,
   guildId: string,
   userId: string,
   now: Date,
-  itx: Parameters<typeof errorFollowUp>[0],
+  itx: RepliableInteraction,
 ) => {
   const result = await getBirthday2026PlayerSnapshot(prisma, guildId, userId, now);
   if (!result.ok) {
@@ -128,7 +125,7 @@ const getPlayerSnapshotOrReply = async (
   return result.snapshot;
 };
 const findTeamByRole = async (
-  prisma: Parameters<typeof findBirthday2026Teams>[0],
+  prisma: PrismaTransaction,
   guildId: string,
   roleId: string,
 ) => {
@@ -340,10 +337,10 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
         command
           .setDescription("Ustaw daty i prywatne flagi eventu")
           .addString("start", (option) =>
-            option.setDescription("Np. 2026-08-03T20:00:00+02:00"),
+            option.setDescription("Np. 2026-08-01T20:00:00+02:00"),
           )
           .addString("koniec", (option) =>
-            option.setDescription("Np. 2026-08-10T20:00:00+02:00"),
+            option.setDescription("Np. 2026-08-08T20:00:00+02:00"),
           )
           .addString("strefa", (option) =>
             option.setDescription("Strefa IANA, np. Europe/Warsaw"),
@@ -374,7 +371,7 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
               if (!eventStartAt || !eventEndAt) {
                 await errorFollowUp(
                   itx,
-                  "Daty muszą być pełnymi znacznikami ISO z offsetem, np. 2026-08-03T20:00:00+02:00.",
+                  "Daty muszą być pełnymi znacznikami ISO z offsetem, np. 2026-08-01T20:00:00+02:00.",
                 );
                 return;
               }

--- a/apps/bot/src/events/birthday2026/index.ts
+++ b/apps/bot/src/events/birthday2026/index.ts
@@ -1,4 +1,5 @@
 import { Hashira } from "@hashira/core";
+import { render } from "@hashira/jsx";
 import {
   bold,
   channelMention,
@@ -25,7 +26,21 @@ import {
   getBirthday2026EventState,
   getBirthday2026RegistrationState,
 } from "./eventState";
-import { parseBirthday2026Instant } from "./staffInput";
+import {
+  type Birthday2026PublicErrorReason,
+  type FeedBirthday2026PlayerResult,
+  feedBirthday2026Player,
+  getBirthday2026PlayerSnapshot,
+} from "./playerService";
+import {
+  BIRTHDAY_2026_FEED_ALL_CUSTOM_ID,
+  buildBirthday2026BalanceView,
+  buildBirthday2026FeedResultView,
+  buildBirthday2026InfoView,
+  buildBirthday2026RankingView,
+  buildBirthday2026StatusView,
+} from "./playerView";
+import { parseBirthday2026Instant, parseBirthday2026TeamColor } from "./staffInput";
 import {
   assignBirthday2026Member,
   createBirthday2026Team,
@@ -80,6 +95,38 @@ const economyErrorMessages: Record<Birthday2026EconomyErrorReason, string> = {
   team_wallet_not_found: "Drużyna nie ma poprawnie skonfigurowanego portfela.",
 };
 
+const publicErrorMessages: Record<Birthday2026PublicErrorReason, string> = {
+  economy_not_configured: "Ekonomia eventu nie jest jeszcze gotowa.",
+  event_not_available: "Event nie jest teraz dostępny.",
+  teams_not_ready: "Drużyny i ich Tucznicy nie są jeszcze gotowi.",
+};
+
+type Birthday2026PlayerFeedErrorReason = Extract<
+  FeedBirthday2026PlayerResult,
+  { ok: false }
+>["reason"];
+
+const playerFeedErrorMessages: Record<Birthday2026PlayerFeedErrorReason, string> = {
+  ...economyErrorMessages,
+  event_not_available: "Event nie jest teraz dostępny.",
+  event_not_open: "Karmienie jest dostępne tylko podczas trwania eventu.",
+  teams_not_ready: "Drużyny i ich Tucznicy nie są jeszcze gotowi.",
+};
+
+const getPlayerSnapshotOrReply = async (
+  prisma: Parameters<typeof getBirthday2026PlayerSnapshot>[0],
+  guildId: string,
+  userId: string,
+  now: Date,
+  itx: Parameters<typeof errorFollowUp>[0],
+) => {
+  const result = await getBirthday2026PlayerSnapshot(prisma, guildId, userId, now);
+  if (!result.ok) {
+    await errorFollowUp(itx, publicErrorMessages[result.reason]);
+    return null;
+  }
+  return result.snapshot;
+};
 const findTeamByRole = async (
   prisma: Parameters<typeof findBirthday2026Teams>[0],
   guildId: string,
@@ -91,6 +138,139 @@ const findTeamByRole = async (
 
 export const birthday2026 = new Hashira({ name: "birthday2026" })
   .use(base)
+  .group("tucznik", (group) =>
+    group
+      .setDescription("Nakarm Tucznika swojej drużyny")
+      .setDMPermission(false)
+      .addCommand("info", (command) =>
+        command
+          .setDescription("Pokaż zasady i czas trwania eventu")
+          .handle(async ({ prisma }, _, itx) => {
+            if (!itx.inCachedGuild()) return;
+            await itx.deferReply();
+
+            const snapshot = await getPlayerSnapshotOrReply(
+              prisma,
+              itx.guildId,
+              itx.user.id,
+              itx.createdAt,
+              itx,
+            );
+            if (!snapshot) return;
+
+            await itx.editReply(render(buildBirthday2026InfoView(snapshot)));
+          }),
+      )
+      .addCommand("saldo", (command) =>
+        command
+          .setDescription("Pokaż prywatne saldo i historię Paszy")
+          .handle(async ({ prisma }, _, itx) => {
+            if (!itx.inCachedGuild()) return;
+            await itx.deferReply({ flags: "Ephemeral" });
+
+            const snapshot = await getPlayerSnapshotOrReply(
+              prisma,
+              itx.guildId,
+              itx.user.id,
+              itx.createdAt,
+              itx,
+            );
+            if (!snapshot) return;
+
+            await itx.editReply(render(buildBirthday2026BalanceView(snapshot)));
+          }),
+      )
+      .addCommand("nakarm", (command) =>
+        command
+          .setDescription("Przekaż Paszę Tucznikowi swojej drużyny")
+          .addInteger("ilosc", (option) =>
+            option.setDescription("Ilość Paszy").setMinValue(1),
+          )
+          .handle(async ({ prisma, messageQueue }, { ilosc: amount }, itx) => {
+            if (!itx.inCachedGuild()) return;
+            await itx.deferReply({ flags: "Ephemeral" });
+            await ensureUserExists(prisma, itx.user);
+
+            const result = await feedBirthday2026Player(prisma, {
+              guildId: itx.guildId,
+              userId: itx.user.id,
+              amount,
+              sourceKey: itx.id,
+              acceptedAt: itx.createdAt,
+              reason: "Birthday 2026 player feed",
+              scheduleDigestion: (tx, batch) =>
+                messageQueue.push(
+                  "birthday2026Digest",
+                  { batchId: batch.id },
+                  batch.digestAt,
+                  batch.id.toString(),
+                  tx,
+                ),
+            });
+            if (!result.ok) {
+              await errorFollowUp(itx, playerFeedErrorMessages[result.reason]);
+              return;
+            }
+
+            const snapshot = await getPlayerSnapshotOrReply(
+              prisma,
+              itx.guildId,
+              itx.user.id,
+              itx.createdAt,
+              itx,
+            );
+            if (!snapshot) return;
+
+            await itx.editReply(
+              render(
+                buildBirthday2026FeedResultView(
+                  snapshot,
+                  result.batch.amount,
+                  result.batch.digestAt,
+                ),
+              ),
+            );
+          }),
+      )
+      .addCommand("status", (command) =>
+        command
+          .setDescription("Pokaż stan wszystkich Tuczników")
+          .handle(async ({ prisma }, _, itx) => {
+            if (!itx.inCachedGuild()) return;
+            await itx.deferReply();
+
+            const snapshot = await getPlayerSnapshotOrReply(
+              prisma,
+              itx.guildId,
+              itx.user.id,
+              itx.createdAt,
+              itx,
+            );
+            if (!snapshot) return;
+
+            await itx.editReply(render(buildBirthday2026StatusView(snapshot)));
+          }),
+      )
+      .addCommand("ranking", (command) =>
+        command
+          .setDescription("Pokaż ranking stałej wagi Tuczników")
+          .handle(async ({ prisma }, _, itx) => {
+            if (!itx.inCachedGuild()) return;
+            await itx.deferReply();
+
+            const snapshot = await getPlayerSnapshotOrReply(
+              prisma,
+              itx.guildId,
+              itx.user.id,
+              itx.createdAt,
+              itx,
+            );
+            if (!snapshot) return;
+
+            await itx.editReply(render(buildBirthday2026RankingView(snapshot)));
+          }),
+      ),
+  )
   .group("urodziny-admin", (group) =>
     group
       .setDescription("Prywatne zarządzanie eventem urodzinowym 2026")
@@ -160,10 +340,10 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
         command
           .setDescription("Ustaw daty i prywatne flagi eventu")
           .addString("start", (option) =>
-            option.setDescription("Np. 2026-08-01T20:00:00+02:00"),
+            option.setDescription("Np. 2026-08-03T20:00:00+02:00"),
           )
           .addString("koniec", (option) =>
-            option.setDescription("Np. 2026-08-08T20:00:00+02:00"),
+            option.setDescription("Np. 2026-08-10T20:00:00+02:00"),
           )
           .addString("strefa", (option) =>
             option.setDescription("Strefa IANA, np. Europe/Warsaw"),
@@ -194,7 +374,7 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
               if (!eventStartAt || !eventEndAt) {
                 await errorFollowUp(
                   itx,
-                  "Daty muszą być pełnymi znacznikami ISO z offsetem, np. 2026-08-01T20:00:00+02:00.",
+                  "Daty muszą być pełnymi znacznikami ISO z offsetem, np. 2026-08-03T20:00:00+02:00.",
                 );
                 return;
               }
@@ -781,4 +961,68 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
       channelId: message.channel.id,
       occurredAt: message.createdAt,
     });
+  })
+  .handle("buttonInteractionCreate", async ({ prisma, messageQueue }, itx) => {
+    if (itx.customId !== BIRTHDAY_2026_FEED_ALL_CUSTOM_ID) return;
+    if (!itx.inCachedGuild()) return;
+
+    await itx.deferReply({ flags: "Ephemeral" });
+    await ensureUserExists(prisma, itx.user);
+
+    const before = await getPlayerSnapshotOrReply(
+      prisma,
+      itx.guildId,
+      itx.user.id,
+      itx.createdAt,
+      itx,
+    );
+    if (!before) return;
+    if (!before.membership) {
+      await errorFollowUp(itx, economyErrorMessages.member_not_found);
+      return;
+    }
+    if (before.balance <= 0) {
+      await errorFollowUp(itx, economyErrorMessages.insufficient_balance);
+      return;
+    }
+
+    const result = await feedBirthday2026Player(prisma, {
+      guildId: itx.guildId,
+      userId: itx.user.id,
+      amount: before.balance,
+      sourceKey: itx.id,
+      acceptedAt: itx.createdAt,
+      reason: "Birthday 2026 player feed",
+      scheduleDigestion: (tx, batch) =>
+        messageQueue.push(
+          "birthday2026Digest",
+          { batchId: batch.id },
+          batch.digestAt,
+          batch.id.toString(),
+          tx,
+        ),
+    });
+    if (!result.ok) {
+      await errorFollowUp(itx, playerFeedErrorMessages[result.reason]);
+      return;
+    }
+
+    const after = await getPlayerSnapshotOrReply(
+      prisma,
+      itx.guildId,
+      itx.user.id,
+      itx.createdAt,
+      itx,
+    );
+    if (!after) return;
+
+    await itx.editReply(
+      render(
+        buildBirthday2026FeedResultView(
+          after,
+          result.batch.amount,
+          result.batch.digestAt,
+        ),
+      ),
+    );
   });

--- a/apps/bot/src/events/birthday2026/playerService.ts
+++ b/apps/bot/src/events/birthday2026/playerService.ts
@@ -1,5 +1,9 @@
 import type { ExtendedPrismaClient, PrismaTransaction } from "@hashira/db";
-import { type FeedBirthday2026PigResult, feedBirthday2026Pig } from "./economyService";
+import {
+  type Birthday2026EconomyErrorReason,
+  type FeedBirthday2026PigInput,
+  feedBirthday2026Pig,
+} from "./economyService";
 import { type Birthday2026EventState, getBirthday2026EventState } from "./eventState";
 
 export type Birthday2026PublicErrorReason =
@@ -71,15 +75,12 @@ export const getBirthday2026PlayerSnapshot = async (
     },
   });
   if (!config?.visible) {
-    return { ok: false, reason: "event_not_available" };
+    return { ok: false, reason: "event_not_available" } as const;
   }
   if (!config.economy) {
-    return { ok: false, reason: "economy_not_configured" };
+    return { ok: false, reason: "economy_not_configured" } as const;
   }
-  if (
-    config.teams.length !== 4 ||
-    config.teams.some((team) => !team.identity || !team.wallet)
-  ) {
+  if (config.teams.some((team) => !team.identity || !team.wallet)) {
     return { ok: false, reason: "teams_not_ready" };
   }
 
@@ -165,19 +166,15 @@ export const getBirthday2026PlayerSnapshot = async (
   };
 };
 
-type FeedBirthday2026PlayerInput = Parameters<typeof feedBirthday2026Pig>[1];
-
-export type FeedBirthday2026PlayerResult =
-  | FeedBirthday2026PigResult
-  | {
-      ok: false;
-      reason: Birthday2026PublicErrorReason | "event_not_open";
-    };
+export type Birthday2026PlayerFeedErrorReason =
+  | Birthday2026EconomyErrorReason
+  | Birthday2026PublicErrorReason
+  | "event_not_open";
 
 export const feedBirthday2026Player = async (
   prisma: ExtendedPrismaClient,
-  input: FeedBirthday2026PlayerInput,
-): Promise<FeedBirthday2026PlayerResult> => {
+  input: FeedBirthday2026PigInput,
+) => {
   const config = await prisma.birthday2026Config.findUnique({
     where: { guildId: input.guildId },
     include: {
@@ -191,19 +188,16 @@ export const feedBirthday2026Player = async (
     },
   });
   if (!config?.visible) {
-    return { ok: false, reason: "event_not_available" };
+    return { ok: false, reason: "event_not_available" } as const;
   }
   if (!config.economy) {
-    return { ok: false, reason: "economy_not_configured" };
+    return { ok: false, reason: "economy_not_configured" } as const;
   }
-  if (
-    config.teams.length !== 4 ||
-    config.teams.some((team) => !team.identity || !team.wallet)
-  ) {
-    return { ok: false, reason: "teams_not_ready" };
+  if (config.teams.some((team) => !team.identity || !team.wallet)) {
+    return { ok: false, reason: "teams_not_ready" } as const;
   }
   if (getBirthday2026EventState(config, input.acceptedAt) !== "open") {
-    return { ok: false, reason: "event_not_open" };
+    return { ok: false, reason: "event_not_open" } as const;
   }
 
   return feedBirthday2026Pig(prisma, input);

--- a/apps/bot/src/events/birthday2026/playerService.ts
+++ b/apps/bot/src/events/birthday2026/playerService.ts
@@ -1,0 +1,210 @@
+import type { ExtendedPrismaClient, PrismaTransaction } from "@hashira/db";
+import { type FeedBirthday2026PigResult, feedBirthday2026Pig } from "./economyService";
+import { type Birthday2026EventState, getBirthday2026EventState } from "./eventState";
+
+export type Birthday2026PublicErrorReason =
+  | "economy_not_configured"
+  | "event_not_available"
+  | "teams_not_ready";
+
+export type Birthday2026PlayerHistoryEntry = {
+  amount: number;
+  createdAt: Date;
+  entryType: "credit" | "debit";
+  reason: string | null;
+  source: "feed" | "staffGrant" | "textActivity";
+};
+
+export type Birthday2026PublicTeam = {
+  captainUserId: string;
+  color: number;
+  contributorCount: number;
+  id: number;
+  name: string;
+  pendingPasza: number;
+  permanentWeight: number;
+  roleId: string;
+  tucznikUserId: string;
+};
+
+export type Birthday2026PlayerSnapshot = {
+  balance: number;
+  contributedPasza: number;
+  currencySymbol: string;
+  eventEndAt: Date;
+  eventStartAt: Date;
+  eventState: Birthday2026EventState;
+  history: Birthday2026PlayerHistoryEntry[];
+  membership: {
+    joinedAt: Date;
+    teamConfigId: number;
+  } | null;
+  teams: Birthday2026PublicTeam[];
+  timezone: string;
+};
+
+export type GetBirthday2026PlayerSnapshotResult =
+  | { ok: true; snapshot: Birthday2026PlayerSnapshot }
+  | { ok: false; reason: Birthday2026PublicErrorReason };
+
+export const getBirthday2026PlayerSnapshot = async (
+  prisma: PrismaTransaction,
+  guildId: string,
+  userId: string,
+  now: Date,
+): Promise<GetBirthday2026PlayerSnapshotResult> => {
+  const config = await prisma.birthday2026Config.findUnique({
+    where: { guildId },
+    include: {
+      economy: { include: { currency: true } },
+      teams: {
+        include: {
+          identity: true,
+          memberStates: {
+            where: { userId },
+            select: { joinedAt: true },
+          },
+          team: true,
+          wallet: true,
+        },
+      },
+    },
+  });
+  if (!config?.visible) {
+    return { ok: false, reason: "event_not_available" };
+  }
+  if (!config.economy) {
+    return { ok: false, reason: "economy_not_configured" };
+  }
+  if (
+    config.teams.length !== 4 ||
+    config.teams.some((team) => !team.identity || !team.wallet)
+  ) {
+    return { ok: false, reason: "teams_not_ready" };
+  }
+
+  const currencyId = config.economy.currencyId;
+  const [wallet, history, contributorRows, contribution] = await Promise.all([
+    prisma.wallet.findFirst({
+      where: { currencyId, default: true, guildId, userId },
+      select: { balance: true },
+    }),
+    prisma.birthday2026PersonalTransaction.findMany({
+      where: { configId: config.id, userId },
+      include: { transaction: true },
+      orderBy: [{ createdAt: "desc" }, { id: "desc" }],
+      take: 5,
+    }),
+    prisma.birthday2026FeedBatch.findMany({
+      where: { configId: config.id },
+      distinct: ["walletId", "userId"],
+      select: { userId: true, walletId: true },
+    }),
+    prisma.birthday2026FeedBatch.aggregate({
+      where: { configId: config.id, userId },
+      _sum: { amount: true },
+    }),
+  ]);
+
+  const contributorCounts = new Map<number, number>();
+  for (const row of contributorRows) {
+    contributorCounts.set(row.walletId, (contributorCounts.get(row.walletId) ?? 0) + 1);
+  }
+
+  const membership = config.teams
+    .flatMap((team) =>
+      team.memberStates.map((memberState) => ({
+        joinedAt: memberState.joinedAt,
+        teamConfigId: team.id,
+      })),
+    )
+    .at(0);
+  const teams = config.teams
+    .map((team): Birthday2026PublicTeam => {
+      if (!team.identity || !team.wallet) {
+        throw new Error("Birthday 2026 public team readiness changed during query");
+      }
+
+      return {
+        captainUserId: team.identity.captainUserId,
+        color: team.color,
+        contributorCount: contributorCounts.get(team.wallet.id) ?? 0,
+        id: team.id,
+        name: team.team.name,
+        pendingPasza: team.wallet.balance,
+        permanentWeight: team.wallet.permanentWeight,
+        roleId: team.roleId,
+        tucznikUserId: team.identity.tucznikUserId,
+      };
+    })
+    .sort(
+      (a, b) =>
+        b.permanentWeight - a.permanentWeight || a.name.localeCompare(b.name, "pl"),
+    );
+
+  return {
+    ok: true,
+    snapshot: {
+      balance: wallet?.balance ?? 0,
+      contributedPasza: contribution._sum.amount ?? 0,
+      currencySymbol: config.economy.currency.symbol,
+      eventEndAt: config.eventEndAt,
+      eventStartAt: config.eventStartAt,
+      eventState: getBirthday2026EventState(config, now),
+      history: history.map((entry) => ({
+        amount: entry.transaction.amount,
+        createdAt: entry.createdAt,
+        entryType: entry.transaction.entryType,
+        reason: entry.transaction.reason,
+        source: entry.source,
+      })),
+      membership: membership ?? null,
+      teams,
+      timezone: config.timezone,
+    },
+  };
+};
+
+type FeedBirthday2026PlayerInput = Parameters<typeof feedBirthday2026Pig>[1];
+
+export type FeedBirthday2026PlayerResult =
+  | FeedBirthday2026PigResult
+  | {
+      ok: false;
+      reason: Birthday2026PublicErrorReason | "event_not_open";
+    };
+
+export const feedBirthday2026Player = async (
+  prisma: ExtendedPrismaClient,
+  input: FeedBirthday2026PlayerInput,
+): Promise<FeedBirthday2026PlayerResult> => {
+  const config = await prisma.birthday2026Config.findUnique({
+    where: { guildId: input.guildId },
+    include: {
+      economy: { select: { configId: true } },
+      teams: {
+        select: {
+          identity: { select: { teamConfigId: true } },
+          wallet: { select: { id: true } },
+        },
+      },
+    },
+  });
+  if (!config?.visible) {
+    return { ok: false, reason: "event_not_available" };
+  }
+  if (!config.economy) {
+    return { ok: false, reason: "economy_not_configured" };
+  }
+  if (
+    config.teams.length !== 4 ||
+    config.teams.some((team) => !team.identity || !team.wallet)
+  ) {
+    return { ok: false, reason: "teams_not_ready" };
+  }
+  if (getBirthday2026EventState(config, input.acceptedAt) !== "open") {
+    return { ok: false, reason: "event_not_open" };
+  }
+
+  return feedBirthday2026Pig(prisma, input);
+};

--- a/apps/bot/src/events/birthday2026/playerView.tsx
+++ b/apps/bot/src/events/birthday2026/playerView.tsx
@@ -27,20 +27,20 @@ import type {
 
 export const BIRTHDAY_2026_FEED_ALL_CUSTOM_ID = "birthday2026-feed-all";
 
-const eventStateLabels: Record<Birthday2026PlayerSnapshot["eventState"], string> = {
+const eventStateLabels = {
   disabled: "wstrzymany",
   finished: "zakończony",
   hidden: "ukryty",
   not_configured: "nieskonfigurowany",
   not_started: "jeszcze się nie rozpoczął",
   open: "trwa",
-};
+} satisfies Record<Birthday2026PlayerSnapshot["eventState"], string>;
 
-const historySourceLabels: Record<Birthday2026PlayerHistoryEntry["source"], string> = {
+const historySourceLabels = {
   feed: "karmienie",
   staffGrant: "korekta administracji",
   textActivity: "aktywność tekstowa",
-};
+} satisfies Record<Birthday2026PlayerHistoryEntry["source"], string>;
 
 const formatPasza = (amount: number, symbol: string) =>
   `${amount.toLocaleString("pl-PL")} ${symbol}`;

--- a/apps/bot/src/events/birthday2026/playerView.tsx
+++ b/apps/bot/src/events/birthday2026/playerView.tsx
@@ -1,0 +1,235 @@
+/** @jsxImportSource @hashira/jsx */
+import {
+  ActionRow,
+  Bold,
+  Br,
+  Button,
+  Container,
+  H1,
+  H2,
+  InlineCode,
+  type JSXNode,
+  Separator,
+  TextDisplay,
+} from "@hashira/jsx";
+import {
+  ButtonStyle,
+  roleMention,
+  TimestampStyles,
+  time,
+  userMention,
+} from "discord.js";
+import type {
+  Birthday2026PlayerHistoryEntry,
+  Birthday2026PlayerSnapshot,
+  Birthday2026PublicTeam,
+} from "./playerService";
+
+export const BIRTHDAY_2026_FEED_ALL_CUSTOM_ID = "birthday2026-feed-all";
+
+const eventStateLabels: Record<Birthday2026PlayerSnapshot["eventState"], string> = {
+  disabled: "wstrzymany",
+  finished: "zakończony",
+  hidden: "ukryty",
+  not_configured: "nieskonfigurowany",
+  not_started: "jeszcze się nie rozpoczął",
+  open: "trwa",
+};
+
+const historySourceLabels: Record<Birthday2026PlayerHistoryEntry["source"], string> = {
+  feed: "karmienie",
+  staffGrant: "korekta administracji",
+  textActivity: "aktywność tekstowa",
+};
+
+const formatPasza = (amount: number, symbol: string) =>
+  `${amount.toLocaleString("pl-PL")} ${symbol}`;
+
+const findPlayerTeam = (snapshot: Birthday2026PlayerSnapshot) =>
+  snapshot.membership
+    ? (snapshot.teams.find((team) => team.id === snapshot.membership?.teamConfigId) ??
+      null)
+    : null;
+
+const formatHistory = (history: Birthday2026PlayerHistoryEntry[], symbol: string) =>
+  history.length > 0
+    ? history
+        .map((entry) => {
+          const sign = entry.entryType === "credit" ? "+" : "−";
+          return `${sign}${formatPasza(entry.amount, symbol)} — ${historySourceLabels[entry.source]} — ${time(entry.createdAt, TimestampStyles.RelativeTime)}`;
+        })
+        .join("\n")
+    : "Brak operacji w tym evencie.";
+
+const getRankingPositions = (teams: Birthday2026PublicTeam[]) => {
+  let previousWeight: number | null = null;
+  let position = 0;
+
+  return teams.map((team, index) => {
+    if (team.permanentWeight !== previousWeight) position = index + 1;
+    previousWeight = team.permanentWeight;
+    return { position, team };
+  });
+};
+
+export const buildBirthday2026InfoView = (
+  snapshot: Birthday2026PlayerSnapshot,
+): JSXNode => {
+  const team = findPlayerTeam(snapshot);
+
+  return (
+    <Container accentColor={team?.color ?? 0xf5a623}>
+      <TextDisplay>
+        <H1>🐗 Nakarm Tucznika</H1>
+        <Br />
+        <Bold>Stan:</Bold> {eventStateLabels[snapshot.eventState]}
+        <Br />
+        <Bold>Start:</Bold> {time(snapshot.eventStartAt, TimestampStyles.LongDateTime)}
+        <Br />
+        <Bold>Koniec:</Bold> {time(snapshot.eventEndAt, TimestampStyles.LongDateTime)}
+        <Br />
+        <Bold>Strefa:</Bold> {snapshot.timezone}
+        <Br />
+        {team ? (
+          <>
+            <Bold>Twoja drużyna:</Bold> {roleMention(team.roleId)} — Tucznik:{" "}
+            {userMention(team.tucznikUserId)}
+          </>
+        ) : (
+          "Nie należysz jeszcze do drużyny eventowej."
+        )}
+      </TextDisplay>
+      <Separator divider />
+      <TextDisplay>
+        Zdobywaj Paszę za aktywność, a następnie użyj{" "}
+        <InlineCode>/tucznik nakarm</InlineCode>, aby przekazać ją Tucznikowi swojej
+        drużyny. Pasza trafia najpierw do koryta, a po trawieniu zwiększa stałą wagę
+        eventową.
+        <Br />
+        Saldo sprawdzisz przez <InlineCode>/tucznik saldo</InlineCode>, a wyniki przez{" "}
+        <InlineCode>/tucznik ranking</InlineCode>.
+      </TextDisplay>
+    </Container>
+  );
+};
+
+export const buildBirthday2026BalanceView = (
+  snapshot: Birthday2026PlayerSnapshot,
+): JSXNode => {
+  const team = findPlayerTeam(snapshot);
+  const canFeed =
+    Boolean(team) && snapshot.balance > 0 && snapshot.eventState === "open";
+
+  return (
+    <Container accentColor={team?.color ?? 0xf5a623}>
+      <TextDisplay>
+        <H1>Twoja Pasza</H1>
+        <Br />
+        <Bold>Saldo:</Bold> {formatPasza(snapshot.balance, snapshot.currencySymbol)}
+        <Br />
+        <Bold>Łącznie przekazano drużynie:</Bold>{" "}
+        {formatPasza(snapshot.contributedPasza, snapshot.currencySymbol)}
+        <Br />
+        <Bold>Drużyna:</Bold>{" "}
+        {team ? roleMention(team.roleId) : "nie należysz do drużyny eventowej"}
+      </TextDisplay>
+      <Separator divider />
+      <TextDisplay>
+        <H2>Ostatnie operacje</H2>
+        <Br />
+        {formatHistory(snapshot.history, snapshot.currencySymbol)}
+      </TextDisplay>
+      <ActionRow>
+        <Button
+          customId={BIRTHDAY_2026_FEED_ALL_CUSTOM_ID}
+          disabled={!canFeed}
+          emoji="🥣"
+          label="Nakarm całą Paszą"
+          style={ButtonStyle.Success}
+        />
+      </ActionRow>
+    </Container>
+  );
+};
+
+export const buildBirthday2026StatusView = (
+  snapshot: Birthday2026PlayerSnapshot,
+): JSXNode => (
+  <Container accentColor={0xf5a623}>
+    <TextDisplay>
+      <H1>Stan Tuczników</H1>
+      <Br />
+      Stała waga jest wynikiem drużyny. Pasza w korycie oczekuje na trawienie.
+    </TextDisplay>
+    {snapshot.teams.map((team) => (
+      <>
+        <Separator divider />
+        <TextDisplay>
+          <H2>{team.name}</H2>
+          <Br />
+          <Bold>Tucznik:</Bold> {userMention(team.tucznikUserId)}
+          <Br />
+          <Bold>Kapitan:</Bold> {userMention(team.captainUserId)}
+          <Br />
+          <Bold>Stała waga:</Bold> {team.permanentWeight.toLocaleString("pl-PL")}
+          <Br />
+          <Bold>W korycie:</Bold>{" "}
+          {formatPasza(team.pendingPasza, snapshot.currencySymbol)}
+          <Br />
+          <Bold>Osoby karmiące:</Bold> {team.contributorCount.toLocaleString("pl-PL")}
+        </TextDisplay>
+      </>
+    ))}
+  </Container>
+);
+
+export const buildBirthday2026RankingView = (
+  snapshot: Birthday2026PlayerSnapshot,
+): JSXNode => (
+  <Container accentColor={0xffd700}>
+    <TextDisplay>
+      <H1>Ranking Tuczników</H1>
+      <Br />
+      {getRankingPositions(snapshot.teams)
+        .map(
+          ({ position, team }) =>
+            `${position}. ${roleMention(team.roleId)} — ${team.permanentWeight.toLocaleString("pl-PL")} stałej wagi (${formatPasza(team.pendingPasza, snapshot.currencySymbol)} w korycie)`,
+        )
+        .join("\n")}
+    </TextDisplay>
+  </Container>
+);
+
+export const buildBirthday2026FeedResultView = (
+  snapshot: Birthday2026PlayerSnapshot,
+  amount: number,
+  digestAt: Date,
+): JSXNode => {
+  const team = findPlayerTeam(snapshot);
+  const canFeedAgain = snapshot.balance > 0 && snapshot.eventState === "open";
+
+  return (
+    <Container accentColor={team?.color ?? 0xf5a623}>
+      <TextDisplay>
+        <H1>🥣 Tucznik nakarmiony!</H1>
+        <Br />
+        Przekazano <Bold>{formatPasza(amount, snapshot.currencySymbol)}</Bold> do koryta{" "}
+        {team ? roleMention(team.roleId) : "Twojej drużyny"}.
+        <Br />
+        <Bold>Pozostałe saldo:</Bold>{" "}
+        {formatPasza(snapshot.balance, snapshot.currencySymbol)}
+        <Br />
+        <Bold>Trawienie:</Bold> {time(digestAt, TimestampStyles.RelativeTime)}
+      </TextDisplay>
+      <ActionRow>
+        <Button
+          customId={BIRTHDAY_2026_FEED_ALL_CUSTOM_ID}
+          disabled={!canFeedAgain}
+          emoji="🥣"
+          label="Nakarm resztą"
+          style={ButtonStyle.Success}
+        />
+      </ActionRow>
+    </Container>
+  );
+};

--- a/apps/bot/test/birthday2026/playerService.database.test.ts
+++ b/apps/bot/test/birthday2026/playerService.database.test.ts
@@ -1,6 +1,5 @@
 import { afterAll, describe, expect, it } from "bun:test";
-import type { PrismaTransaction } from "@hashira/db";
-import { PrismaClient } from "@hashira/prisma-client";
+import { PrismaClient, type PrismaTransaction } from "@hashira/db";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { upsertBirthday2026Config } from "../../src/events/birthday2026/configService";
 import {

--- a/apps/bot/test/birthday2026/playerService.database.test.ts
+++ b/apps/bot/test/birthday2026/playerService.database.test.ts
@@ -13,7 +13,7 @@ import {
 import {
   assignBirthday2026Member,
   createBirthday2026Team,
-  setBirthday2026Tucznik,
+  createBirthday2026TeamIdentity,
 } from "../../src/events/birthday2026/teamService";
 
 const connectionString = process.env.DATABASE_TEST_URL;
@@ -56,14 +56,28 @@ const createFixture = async () => {
     { length: 4 },
     (_, index) => `birthday-player-tucznik-${index}-${suffix}`,
   );
+  const captainUserIds = Array.from(
+    { length: 4 },
+    (_, index) => `birthday-player-captain-${index}-${suffix}`,
+  );
   guildIds.push(guildId);
-  userIds.push(actorUserId, memberUserId, nonMemberUserId, ...tucznikUserIds);
+  userIds.push(
+    actorUserId,
+    memberUserId,
+    nonMemberUserId,
+    ...captainUserIds,
+    ...tucznikUserIds,
+  );
 
   await prisma.guild.create({ data: { id: guildId } });
   await prisma.user.createMany({
-    data: [actorUserId, memberUserId, nonMemberUserId, ...tucznikUserIds].map((id) => ({
-      id,
-    })),
+    data: [
+      actorUserId,
+      memberUserId,
+      nonMemberUserId,
+      ...captainUserIds,
+      ...tucznikUserIds,
+    ].map((id) => ({ id })),
   });
 
   const configResult = await upsertBirthday2026Config(prisma, {
@@ -78,6 +92,9 @@ const createFixture = async () => {
 
   const teams = [];
   for (const [index, tucznikUserId] of tucznikUserIds.entries()) {
+    const captainUserId = captainUserIds[index];
+    if (!captainUserId) throw new Error("Player fixture captain is missing");
+
     const teamResult = await createBirthday2026Team(prisma, {
       guildId,
       name: `Team ${index + 1} ${suffix}`,
@@ -87,18 +104,20 @@ const createFixture = async () => {
     if (!teamResult.ok) throw new Error(teamResult.reason);
     teams.push(teamResult.team);
 
-    const assignment = await assignBirthday2026Member(prisma, {
-      guildId,
-      teamConfigId: teamResult.team.id,
-      userId: tucznikUserId,
-    });
-    if (!assignment.ok) throw new Error(assignment.reason);
+    for (const userId of [captainUserId, tucznikUserId]) {
+      const assignment = await assignBirthday2026Member(prisma, {
+        guildId,
+        teamConfigId: teamResult.team.id,
+        userId,
+      });
+      if (!assignment.ok) throw new Error(assignment.reason);
+    }
 
-    const identity = await setBirthday2026Tucznik(
+    const identity = await createBirthday2026TeamIdentity(
       prisma,
       guildId,
       teamResult.team.id,
-      tucznikUserId,
+      { captainUserId, tucznikUserId },
     );
     if (!identity.ok) throw new Error(identity.reason);
   }

--- a/apps/bot/test/birthday2026/playerService.database.test.ts
+++ b/apps/bot/test/birthday2026/playerService.database.test.ts
@@ -1,0 +1,263 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import type { PrismaTransaction } from "@hashira/db";
+import { PrismaClient } from "@hashira/prisma-client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { upsertBirthday2026Config } from "../../src/events/birthday2026/configService";
+import {
+  grantBirthday2026Pasza,
+  setupBirthday2026Economy,
+} from "../../src/events/birthday2026/economyService";
+import {
+  feedBirthday2026Player,
+  getBirthday2026PlayerSnapshot,
+} from "../../src/events/birthday2026/playerService";
+import {
+  assignBirthday2026Member,
+  createBirthday2026Team,
+  setBirthday2026Tucznik,
+} from "../../src/events/birthday2026/teamService";
+
+const connectionString = process.env.DATABASE_TEST_URL;
+const databaseTests = describe.skipIf(!connectionString);
+const prisma = connectionString
+  ? new PrismaClient({ adapter: new PrismaPg({ connectionString }) })
+  : null;
+
+const guildIds: string[] = [];
+const userIds: string[] = [];
+const currencyIds: number[] = [];
+const taskIds: number[] = [];
+
+const scheduleDigestion = async (
+  tx: PrismaTransaction,
+  batch: { digestAt: Date; id: number },
+) => {
+  const task = await tx.task.create({
+    data: {
+      data: {
+        type: "birthday2026Digest",
+        data: { batchId: batch.id },
+      },
+      handleAfter: batch.digestAt,
+      identifier: batch.id.toString(),
+    },
+  });
+  taskIds.push(task.id);
+};
+
+const createFixture = async () => {
+  if (!prisma) throw new Error("DATABASE_TEST_URL is required");
+
+  const suffix = crypto.randomUUID();
+  const guildId = `birthday-player-guild-${suffix}`;
+  const actorUserId = `birthday-player-actor-${suffix}`;
+  const memberUserId = `birthday-player-member-${suffix}`;
+  const nonMemberUserId = `birthday-player-non-member-${suffix}`;
+  const tucznikUserIds = Array.from(
+    { length: 4 },
+    (_, index) => `birthday-player-tucznik-${index}-${suffix}`,
+  );
+  guildIds.push(guildId);
+  userIds.push(actorUserId, memberUserId, nonMemberUserId, ...tucznikUserIds);
+
+  await prisma.guild.create({ data: { id: guildId } });
+  await prisma.user.createMany({
+    data: [actorUserId, memberUserId, nonMemberUserId, ...tucznikUserIds].map((id) => ({
+      id,
+    })),
+  });
+
+  const configResult = await upsertBirthday2026Config(prisma, {
+    guildId,
+    eventStartAt: new Date("2026-08-03T18:00:00Z"),
+    eventEndAt: new Date("2026-08-10T18:00:00Z"),
+    timezone: "Europe/Warsaw",
+    visible: true,
+    enabled: true,
+  });
+  if (!configResult.ok) throw new Error(configResult.reason);
+
+  const teams = [];
+  for (const [index, tucznikUserId] of tucznikUserIds.entries()) {
+    const teamResult = await createBirthday2026Team(prisma, {
+      guildId,
+      name: `Team ${index + 1} ${suffix}`,
+      roleId: `birthday-player-role-${index}-${suffix}`,
+      color: 0xff8800 + index,
+    });
+    if (!teamResult.ok) throw new Error(teamResult.reason);
+    teams.push(teamResult.team);
+
+    const assignment = await assignBirthday2026Member(prisma, {
+      guildId,
+      teamConfigId: teamResult.team.id,
+      userId: tucznikUserId,
+    });
+    if (!assignment.ok) throw new Error(assignment.reason);
+
+    const identity = await setBirthday2026Tucznik(
+      prisma,
+      guildId,
+      teamResult.team.id,
+      tucznikUserId,
+    );
+    if (!identity.ok) throw new Error(identity.reason);
+  }
+
+  const playerTeam = teams[0];
+  if (!playerTeam) throw new Error("Player fixture did not create a team");
+  const memberAssignment = await assignBirthday2026Member(prisma, {
+    guildId,
+    teamConfigId: playerTeam.id,
+    userId: memberUserId,
+  });
+  if (!memberAssignment.ok) throw new Error(memberAssignment.reason);
+
+  const economy = await setupBirthday2026Economy(prisma, {
+    guildId,
+    currencyName: `Pasza ${suffix}`,
+    currencySymbol: `P${suffix.slice(0, 6)}`,
+    digestionDelaySeconds: 14_400,
+    createdByUserId: actorUserId,
+  });
+  if (!economy.ok) throw new Error(economy.reason);
+  currencyIds.push(economy.currencyId);
+
+  const grant = await grantBirthday2026Pasza(prisma, {
+    guildId,
+    userId: memberUserId,
+    amount: 12,
+    sourceKey: `fixture-grant-${suffix}`,
+    createdByUserId: actorUserId,
+    reason: "Player loop fixture",
+  });
+  if (!grant.ok) throw new Error(grant.reason);
+
+  return {
+    guildId,
+    memberUserId,
+    nonMemberUserId,
+    team: playerTeam,
+  };
+};
+
+databaseTests("Birthday 2026 public player loop", () => {
+  afterAll(async () => {
+    if (!prisma) return;
+
+    await prisma.task.deleteMany({ where: { id: { in: taskIds } } });
+    await prisma.birthday2026TeamWalletTransaction.deleteMany({
+      where: { wallet: { teamConfig: { config: { guildId: { in: guildIds } } } } },
+    });
+    await prisma.birthday2026Config.deleteMany({
+      where: { guildId: { in: guildIds } },
+    });
+    await prisma.transaction.deleteMany({
+      where: { wallet: { currencyId: { in: currencyIds } } },
+    });
+    await prisma.wallet.deleteMany({ where: { currencyId: { in: currencyIds } } });
+    await prisma.currency.deleteMany({ where: { id: { in: currencyIds } } });
+    await prisma.team.deleteMany({ where: { guildId: { in: guildIds } } });
+    await prisma.guild.deleteMany({ where: { id: { in: guildIds } } });
+    await prisma.user.deleteMany({ where: { id: { in: userIds } } });
+    await prisma.$disconnect();
+  });
+
+  it("builds a private player snapshot and updates it after feeding", async () => {
+    if (!prisma) throw new Error("DATABASE_TEST_URL is required");
+    const fixture = await createFixture();
+
+    const before = await getBirthday2026PlayerSnapshot(
+      prisma,
+      fixture.guildId,
+      fixture.memberUserId,
+      new Date("2026-08-03T18:00:00Z"),
+    );
+    expect(before.ok).toBeTrue();
+    if (!before.ok) return;
+    expect(before.snapshot.balance).toBe(12);
+    expect(before.snapshot.contributedPasza).toBe(0);
+    expect(before.snapshot.membership?.teamConfigId).toBe(fixture.team.id);
+    expect(before.snapshot.teams).toHaveLength(4);
+    expect(before.snapshot.history.map((entry) => entry.source)).toEqual([
+      "staffGrant",
+    ]);
+
+    const feed = await feedBirthday2026Player(prisma, {
+      guildId: fixture.guildId,
+      userId: fixture.memberUserId,
+      amount: 5,
+      sourceKey: `player-feed-${crypto.randomUUID()}`,
+      acceptedAt: new Date("2026-08-03T18:00:00Z"),
+      reason: "Player command feed",
+      scheduleDigestion,
+    });
+    expect(feed.ok).toBeTrue();
+
+    const after = await getBirthday2026PlayerSnapshot(
+      prisma,
+      fixture.guildId,
+      fixture.memberUserId,
+      new Date("2026-08-03T18:01:00Z"),
+    );
+    expect(after.ok).toBeTrue();
+    if (!after.ok) return;
+    expect(after.snapshot.balance).toBe(7);
+    expect(after.snapshot.contributedPasza).toBe(5);
+    expect(after.snapshot.history.map((entry) => entry.source)).toEqual([
+      "feed",
+      "staffGrant",
+    ]);
+    expect(
+      after.snapshot.teams.find((team) => team.id === fixture.team.id),
+    ).toMatchObject({ contributorCount: 1, pendingPasza: 5 });
+  });
+
+  it("gates public feeding by readiness, event window, and membership", async () => {
+    if (!prisma) throw new Error("DATABASE_TEST_URL is required");
+    const fixture = await createFixture();
+    const input = {
+      guildId: fixture.guildId,
+      userId: fixture.memberUserId,
+      amount: 1,
+      sourceKey: `gated-feed-${crypto.randomUUID()}`,
+      acceptedAt: new Date("2026-08-03T17:59:59Z"),
+      reason: "Gated player feed",
+      scheduleDigestion,
+    };
+
+    expect(await feedBirthday2026Player(prisma, input)).toEqual({
+      ok: false,
+      reason: "event_not_open",
+    });
+
+    const nonMemberSnapshot = await getBirthday2026PlayerSnapshot(
+      prisma,
+      fixture.guildId,
+      fixture.nonMemberUserId,
+      new Date("2026-08-03T18:00:00Z"),
+    );
+    expect(nonMemberSnapshot.ok).toBeTrue();
+    if (nonMemberSnapshot.ok) {
+      expect(nonMemberSnapshot.snapshot.membership).toBeNull();
+    }
+    expect(
+      await feedBirthday2026Player(prisma, {
+        ...input,
+        userId: fixture.nonMemberUserId,
+        sourceKey: `non-member-feed-${crypto.randomUUID()}`,
+        acceptedAt: new Date("2026-08-03T18:00:00Z"),
+      }),
+    ).toEqual({ ok: false, reason: "member_not_found" });
+
+    await prisma.birthday2026TeamIdentity.delete({
+      where: { teamConfigId: fixture.team.id },
+    });
+    expect(
+      await feedBirthday2026Player(prisma, {
+        ...input,
+        acceptedAt: new Date("2026-08-03T18:00:00Z"),
+      }),
+    ).toEqual({ ok: false, reason: "teams_not_ready" });
+  });
+});

--- a/apps/bot/test/birthday2026/playerView.test.tsx
+++ b/apps/bot/test/birthday2026/playerView.test.tsx
@@ -1,0 +1,144 @@
+/** @jsxImportSource @hashira/jsx */
+import { describe, expect, it } from "bun:test";
+import { render } from "@hashira/jsx";
+import type { Birthday2026PlayerSnapshot } from "../../src/events/birthday2026/playerService";
+import {
+  BIRTHDAY_2026_FEED_ALL_CUSTOM_ID,
+  buildBirthday2026BalanceView,
+  buildBirthday2026FeedResultView,
+  buildBirthday2026InfoView,
+  buildBirthday2026RankingView,
+  buildBirthday2026StatusView,
+} from "../../src/events/birthday2026/playerView";
+
+const snapshot: Birthday2026PlayerSnapshot = {
+  balance: 12,
+  contributedPasza: 5,
+  currencySymbol: "P",
+  eventEndAt: new Date("2026-08-10T18:00:00Z"),
+  eventStartAt: new Date("2026-08-03T18:00:00Z"),
+  eventState: "open",
+  history: [
+    {
+      amount: 5,
+      createdAt: new Date("2026-08-03T18:05:00Z"),
+      entryType: "debit",
+      reason: "Player feed",
+      source: "feed",
+    },
+    {
+      amount: 17,
+      createdAt: new Date("2026-08-03T18:00:00Z"),
+      entryType: "credit",
+      reason: "Text activity",
+      source: "textActivity",
+    },
+  ],
+  membership: {
+    joinedAt: new Date("2026-08-02T18:00:00Z"),
+    teamConfigId: 1,
+  },
+  teams: [
+    {
+      captainUserId: "captain-1",
+      color: 0xff0000,
+      contributorCount: 4,
+      id: 1,
+      name: "Czerwoni",
+      pendingPasza: 15,
+      permanentWeight: 30,
+      roleId: "role-1",
+      tucznikUserId: "tucznik-1",
+    },
+    {
+      captainUserId: "captain-2",
+      color: 0x00ff00,
+      contributorCount: 3,
+      id: 2,
+      name: "Zieloni",
+      pendingPasza: 10,
+      permanentWeight: 30,
+      roleId: "role-2",
+      tucznikUserId: "tucznik-2",
+    },
+    {
+      captainUserId: "captain-3",
+      color: 0x0000ff,
+      contributorCount: 2,
+      id: 3,
+      name: "Niebiescy",
+      pendingPasza: 8,
+      permanentWeight: 20,
+      roleId: "role-3",
+      tucznikUserId: "tucznik-3",
+    },
+    {
+      captainUserId: "captain-4",
+      color: 0xffff00,
+      contributorCount: 1,
+      id: 4,
+      name: "Żółci",
+      pendingPasza: 2,
+      permanentWeight: 10,
+      roleId: "role-4",
+      tucznikUserId: "tucznik-4",
+    },
+  ],
+  timezone: "Europe/Warsaw",
+};
+
+const renderJson = (element: Parameters<typeof render>[0]) => {
+  const rendered = render(element);
+  expect(rendered.flags).toBe("IsComponentsV2");
+  return JSON.stringify(rendered.components);
+};
+
+describe("Birthday 2026 player JSX views", () => {
+  it("renders event info and all public team status", () => {
+    const info = renderJson(buildBirthday2026InfoView(snapshot));
+    expect(info).toContain("Nakarm Tucznika");
+    expect(info).toContain("/tucznik nakarm");
+    expect(info).toContain("tucznik-1");
+
+    const status = renderJson(buildBirthday2026StatusView(snapshot));
+    for (const team of snapshot.teams) {
+      expect(status).toContain(team.name);
+      expect(status).toContain(team.tucznikUserId);
+      expect(status).toContain(team.captainUserId);
+    }
+  });
+
+  it("renders private balance, history, and an enabled feed-all button", () => {
+    const balance = renderJson(buildBirthday2026BalanceView(snapshot));
+    expect(balance).toContain("Twoja Pasza");
+    expect(balance).toContain("−5 P");
+    expect(balance).toContain("+17 P");
+    expect(balance).toContain(BIRTHDAY_2026_FEED_ALL_CUSTOM_ID);
+    expect(balance).not.toContain('"disabled":true');
+  });
+
+  it("disables feeding outside the open event window", () => {
+    const balance = renderJson(
+      buildBirthday2026BalanceView({ ...snapshot, eventState: "finished" }),
+    );
+    expect(balance).toContain('"disabled":true');
+  });
+
+  it("renders tied rankings and feed confirmation", () => {
+    const ranking = renderJson(buildBirthday2026RankingView(snapshot));
+    expect(ranking).toContain("1. <@&role-1>");
+    expect(ranking).toContain("1. <@&role-2>");
+    expect(ranking).toContain("3. <@&role-3>");
+
+    const result = renderJson(
+      buildBirthday2026FeedResultView(
+        { ...snapshot, balance: 7 },
+        5,
+        new Date("2026-08-03T22:05:00Z"),
+      ),
+    );
+    expect(result).toContain("Tucznik nakarmiony");
+    expect(result).toContain("Pozostałe saldo");
+    expect(result).toContain(BIRTHDAY_2026_FEED_ALL_CUSTOM_ID);
+  });
+});


### PR DESCRIPTION
## Summary

- add the public `/tucznik` info, private balance/history, feed, status, and ranking commands
- render the player surface with the repository JSX Components V2 implementation
- route amount-based and feed-all button actions through the same player-gated feeding service
- require a visible event, configured economy, four ready Tucznicy/team wallets, an open event window, and event membership where applicable
- move the planned event window to August 3–10, 2026 at 20:00 Warsaw time

## Validation

- `bun run typecheck`
- all 53 migrations on a fresh PostgreSQL database
- `bun test apps/bot/test/birthday2026`: 34 passed
- full `bun test`: 398 passed, 1 skipped

<sub>Part of stack #276; based on PR #280.</sub>