### PR TITLE
feat(birthday2026): award Pasza for voice activity

### DIFF
--- a/apps/bot/src/events/birthday2026/eventState.ts
+++ b/apps/bot/src/events/birthday2026/eventState.ts
@@ -1,6 +1,6 @@
 import type { Birthday2026Config } from "@hashira/db";
 
-const MILLISECONDS_PER_EVENT_DAY = 24 * 60 * 60 * 1000;
+export const MILLISECONDS_PER_EVENT_DAY = 24 * 60 * 60 * 1000;
 
 export type Birthday2026EventState =
   | "not_configured"

--- a/apps/bot/src/events/birthday2026/index.ts
+++ b/apps/bot/src/events/birthday2026/index.ts
@@ -60,6 +60,10 @@ import {
   findBirthday2026DisabledTextChannels,
   getBirthday2026TextEarningDiagnostics,
 } from "./textEarningService";
+import {
+  configureBirthday2026VoiceEarning,
+  getBirthday2026VoiceEarningDiagnostics,
+} from "./voiceEarningService";
 
 const teamErrorMessages = {
   already_in_team: "Ten użytkownik jest już w tej drużynie.",
@@ -286,11 +290,13 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
               return;
             }
 
-            const [teams, disabledTextChannels, textDiagnostics] = await Promise.all([
-              findBirthday2026Teams(prisma, itx.guildId),
-              findBirthday2026DisabledTextChannels(prisma, itx.guildId),
-              getBirthday2026TextEarningDiagnostics(prisma, itx.guildId),
-            ]);
+            const [teams, disabledTextChannels, textDiagnostics, voiceDiagnostics] =
+              await Promise.all([
+                findBirthday2026Teams(prisma, itx.guildId),
+                findBirthday2026DisabledTextChannels(prisma, itx.guildId),
+                getBirthday2026TextEarningDiagnostics(prisma, itx.guildId),
+                getBirthday2026VoiceEarningDiagnostics(prisma, itx.guildId),
+              ]);
             const now = new Date();
             const configuredTucznicy = teams.filter((team) =>
               Boolean(team.identity?.tucznikUserId),
@@ -326,6 +332,12 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
                     : "nie skonfigurowano"
                 }`,
                 `${bold("Naliczona Pasza tekstowa:")} ${textDiagnostics?.awardedTransactions ?? 0} — liczniki=${textDiagnostics?.counterTotal ?? 0}, dni użytkowników=${textDiagnostics?.dailyRows ?? 0}, spójne=${textDiagnostics?.reconciled ? "tak" : "NIE"}`,
+                `${bold("Głos:")} ${
+                  voiceDiagnostics
+                    ? `jednostka=${voiceDiagnostics.unitSeconds}s, limit=${voiceDiagnostics.dailyCap}/dzień`
+                    : "nie skonfigurowano"
+                }`,
+                `${bold("Naliczona Pasza głosowa:")} ${voiceDiagnostics?.awardedPasza ?? 0} w ${voiceDiagnostics?.awardedTransactions ?? 0} transakcjach — liczniki=${voiceDiagnostics?.counterTotal ?? 0}, dni użytkowników=${voiceDiagnostics?.dailyRows ?? 0}, spójne=${voiceDiagnostics?.reconciled ? "tak" : "NIE"}`,
                 `${bold("Tucznicy:")} ${configuredTucznicy}/${teams.length} — gotowość: ${tucznicyReady ? "tak" : "nie"}`,
                 `${bold("Drużyny:")}`,
                 teamLines.join("\n") || "brak",
@@ -523,6 +535,49 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
 
               await itx.editReply(
                 `Zdobywanie Paszy za tekst: okno ${windowMinutes} min, limit ${dailyCap} na dzień eventowy.`,
+              );
+            },
+          ),
+      )
+      .addCommand("glos", (command) =>
+        command
+          .setDescription("Skonfiguruj automatyczne zdobywanie Paszy za głos")
+          .addInteger("jednostka-minuty", (option) =>
+            option.setDescription("Minuty aktywnego głosu na 1 Paszę").setMinValue(1),
+          )
+          .addInteger("limit-dzienny", (option) =>
+            option.setDescription("Maksymalna Pasza dziennie").setMinValue(1),
+          )
+          .handle(
+            async (
+              { prisma },
+              { "jednostka-minuty": unitMinutes, "limit-dzienny": dailyCap },
+              itx,
+            ) => {
+              if (!itx.inCachedGuild()) return;
+              await itx.deferReply({ flags: "Ephemeral" });
+
+              const result = await configureBirthday2026VoiceEarning(prisma, {
+                guildId: itx.guildId,
+                unitSeconds: unitMinutes * 60,
+                dailyCap,
+              });
+              if (!result.ok) {
+                const messages = {
+                  config_not_found:
+                    "Najpierw skonfiguruj daty eventu komendą `konfiguruj`.",
+                  invalid_daily_cap:
+                    "Limit dzienny musi być dodatnią liczbą całkowitą.",
+                  invalid_unit: "Jednostka głosowa musi być dodatnią liczbą minut.",
+                  voice_earning_already_used:
+                    "Nie można zmienić reguł głosowych po przyznaniu pierwszej Paszy.",
+                };
+                await errorFollowUp(itx, messages[result.reason]);
+                return;
+              }
+
+              await itx.editReply(
+                `Zdobywanie Paszy za głos: jednostka ${unitMinutes} min, limit ${dailyCap} na dzień eventowy.`,
               );
             },
           ),

--- a/apps/bot/src/events/birthday2026/playerService.ts
+++ b/apps/bot/src/events/birthday2026/playerService.ts
@@ -16,7 +16,7 @@ export type Birthday2026PlayerHistoryEntry = {
   createdAt: Date;
   entryType: "credit" | "debit";
   reason: string | null;
-  source: "feed" | "staffGrant" | "textActivity";
+  source: "feed" | "staffGrant" | "textActivity" | "voiceActivity";
 };
 
 export type Birthday2026PublicTeam = {

--- a/apps/bot/src/events/birthday2026/playerView.tsx
+++ b/apps/bot/src/events/birthday2026/playerView.tsx
@@ -40,6 +40,7 @@ const historySourceLabels = {
   feed: "karmienie",
   staffGrant: "korekta administracji",
   textActivity: "aktywność tekstowa",
+  voiceActivity: "aktywność głosowa",
 } satisfies Record<Birthday2026PlayerHistoryEntry["source"], string>;
 
 const formatPasza = (amount: number, symbol: string) =>

--- a/apps/bot/src/events/birthday2026/voiceEarningService.ts
+++ b/apps/bot/src/events/birthday2026/voiceEarningService.ts
@@ -1,0 +1,314 @@
+import type {
+  Birthday2026VoiceEarningConfig,
+  ExtendedPrismaClient,
+  PrismaTransaction,
+} from "@hashira/db";
+import { nestedTransaction } from "@hashira/db/transaction";
+import { getDefaultWallet } from "../../economy/managers/walletManager";
+import { getBirthday2026EventDayIndex, getBirthday2026EventState } from "./eventState";
+
+export type ConfigureBirthday2026VoiceEarningResult =
+  | { ok: true; config: Birthday2026VoiceEarningConfig }
+  | {
+      ok: false;
+      reason:
+        | "config_not_found"
+        | "invalid_daily_cap"
+        | "invalid_unit"
+        | "voice_earning_already_used";
+    };
+
+export const configureBirthday2026VoiceEarning = async (
+  prisma: ExtendedPrismaClient,
+  input: {
+    guildId: string;
+    unitSeconds: number;
+    dailyCap: number;
+  },
+): Promise<ConfigureBirthday2026VoiceEarningResult> => {
+  if (!Number.isSafeInteger(input.unitSeconds) || input.unitSeconds <= 0) {
+    return { ok: false, reason: "invalid_unit" };
+  }
+  if (!Number.isSafeInteger(input.dailyCap) || input.dailyCap <= 0) {
+    return { ok: false, reason: "invalid_daily_cap" };
+  }
+
+  return prisma.$transaction(async (tx) => {
+    const config = await tx.birthday2026Config.findUnique({
+      where: { guildId: input.guildId },
+      include: { voiceEarning: true },
+    });
+    if (!config) return { ok: false, reason: "config_not_found" };
+    if (
+      config.voiceEarning?.unitSeconds === input.unitSeconds &&
+      config.voiceEarning.dailyCap === input.dailyCap
+    ) {
+      return { ok: true, config: config.voiceEarning };
+    }
+
+    const existingAward = await tx.birthday2026PersonalTransaction.findFirst({
+      where: { configId: config.id, source: "voiceActivity" },
+      select: { id: true },
+    });
+    if (existingAward) {
+      return { ok: false, reason: "voice_earning_already_used" };
+    }
+
+    return {
+      ok: true,
+      config: await tx.birthday2026VoiceEarningConfig.upsert({
+        where: { configId: config.id },
+        create: {
+          configId: config.id,
+          unitSeconds: input.unitSeconds,
+          dailyCap: input.dailyCap,
+        },
+        update: {
+          unitSeconds: input.unitSeconds,
+          dailyCap: input.dailyCap,
+        },
+      }),
+    };
+  });
+};
+
+export const getBirthday2026VoiceEarningDiagnostics = async (
+  prisma: PrismaTransaction,
+  guildId: string,
+) => {
+  const config = await prisma.birthday2026Config.findUnique({
+    where: { guildId },
+    select: { id: true, voiceEarning: true },
+  });
+  if (!config?.voiceEarning) return null;
+
+  const [dailyCounters, awards] = await Promise.all([
+    prisma.birthday2026DailyVoiceEarning.aggregate({
+      where: { configId: config.id },
+      _count: { _all: true },
+      _sum: { awardedUnits: true },
+    }),
+    prisma.birthday2026PersonalTransaction.findMany({
+      where: { configId: config.id, source: "voiceActivity" },
+      select: { transaction: { select: { amount: true } } },
+    }),
+  ]);
+  const counterTotal = dailyCounters._sum.awardedUnits ?? 0;
+  const awardedPasza = awards.reduce(
+    (total, award) => total + award.transaction.amount,
+    0,
+  );
+
+  return {
+    awardedPasza,
+    awardedTransactions: awards.length,
+    counterTotal,
+    dailyCap: config.voiceEarning.dailyCap,
+    dailyRows: dailyCounters._count._all,
+    reconciled: counterTotal === awardedPasza,
+    unitSeconds: config.voiceEarning.unitSeconds,
+  };
+};
+
+export type AwardBirthday2026VoicePaszaErrorReason =
+  | "activity_before_join"
+  | "config_not_found"
+  | "economy_not_configured"
+  | "event_not_open"
+  | "member_not_found"
+  | "voice_earning_not_configured"
+  | "voice_session_not_found";
+
+export type AwardBirthday2026VoicePaszaResult =
+  | {
+      ok: true;
+      awardedUnits: number;
+      dailyAwardedUnits: number;
+      eligibleSeconds: number;
+      eventDayIndex: number;
+      status: "awarded" | "noop";
+      walletBalance: number;
+    }
+  | { ok: false; reason: AwardBirthday2026VoicePaszaErrorReason };
+
+export const awardBirthday2026VoicePasza = async (
+  prisma: ExtendedPrismaClient,
+  input: { voiceSessionId: number },
+): Promise<AwardBirthday2026VoicePaszaResult> => {
+  const voiceSession = await prisma.voiceSession.findUnique({
+    where: { id: input.voiceSessionId },
+    select: {
+      guildId: true,
+      id: true,
+      joinedAt: true,
+      leftAt: true,
+      userId: true,
+    },
+  });
+  if (!voiceSession) {
+    return { ok: false, reason: "voice_session_not_found" };
+  }
+
+  const config = await prisma.birthday2026Config.findUnique({
+    where: { guildId: voiceSession.guildId },
+    include: {
+      economy: { select: { currencyId: true } },
+      voiceEarning: true,
+    },
+  });
+  if (!config) return { ok: false, reason: "config_not_found" };
+  if (getBirthday2026EventState(config, voiceSession.joinedAt) !== "open") {
+    return { ok: false, reason: "event_not_open" };
+  }
+  if (!config.economy) {
+    return { ok: false, reason: "economy_not_configured" };
+  }
+  if (!config.voiceEarning) {
+    return { ok: false, reason: "voice_earning_not_configured" };
+  }
+  const currencyId = config.economy.currencyId;
+  const voiceEarning = config.voiceEarning;
+
+  const membership = await prisma.birthday2026MemberState.findUnique({
+    where: {
+      configId_userId: {
+        configId: config.id,
+        userId: voiceSession.userId,
+      },
+    },
+    select: { joinedAt: true },
+  });
+  if (!membership) return { ok: false, reason: "member_not_found" };
+  if (voiceSession.joinedAt < membership.joinedAt) {
+    return { ok: false, reason: "activity_before_join" };
+  }
+
+  const eventDayIndex = getBirthday2026EventDayIndex(config, voiceSession.joinedAt);
+  if (eventDayIndex === null) {
+    return { ok: false, reason: "event_not_open" };
+  }
+  const dayStart = new Date(config.eventStartAt.getTime() + eventDayIndex * 86_400_000);
+  const dayEnd = new Date(dayStart.getTime() + 86_400_000);
+  const eligibleTime = await prisma.voiceSessionTotal.aggregate({
+    where: {
+      isAlone: false,
+      isDeafened: false,
+      isMuted: false,
+      voiceSession: {
+        guildId: voiceSession.guildId,
+        joinedAt: {
+          gte: membership.joinedAt > dayStart ? membership.joinedAt : dayStart,
+          lt: dayEnd,
+        },
+        userId: voiceSession.userId,
+      },
+    },
+    _sum: { secondsSpent: true },
+  });
+  const eligibleSeconds = eligibleTime._sum.secondsSpent ?? 0;
+  const targetUnits = Math.min(
+    Math.floor(eligibleSeconds / voiceEarning.unitSeconds),
+    voiceEarning.dailyCap,
+  );
+  const sourceKey = `voice-session:${voiceSession.id}`;
+
+  return prisma.$transaction(async (tx) => {
+    await tx.birthday2026DailyVoiceEarning.createMany({
+      data: {
+        configId: config.id,
+        userId: voiceSession.userId,
+        eventDayIndex,
+        awardedUnits: 0,
+      },
+      skipDuplicates: true,
+    });
+
+    let awardedUnits = 0;
+    while (awardedUnits < targetUnits) {
+      const update = await tx.birthday2026DailyVoiceEarning.updateMany({
+        where: {
+          configId: config.id,
+          userId: voiceSession.userId,
+          eventDayIndex,
+          awardedUnits: { lt: targetUnits },
+        },
+        data: { awardedUnits: { increment: 1 } },
+      });
+      if (update.count === 0) break;
+      awardedUnits += 1;
+    }
+
+    const dailyState = await tx.birthday2026DailyVoiceEarning.findUniqueOrThrow({
+      where: {
+        configId_userId_eventDayIndex: {
+          configId: config.id,
+          userId: voiceSession.userId,
+          eventDayIndex,
+        },
+      },
+      select: { awardedUnits: true },
+    });
+
+    if (awardedUnits === 0) {
+      const wallet = await tx.wallet.findFirst({
+        where: {
+          currencyId,
+          default: true,
+          guildId: voiceSession.guildId,
+          userId: voiceSession.userId,
+        },
+        select: { balance: true },
+      });
+      return {
+        ok: true,
+        awardedUnits: 0,
+        dailyAwardedUnits: dailyState.awardedUnits,
+        eligibleSeconds,
+        eventDayIndex,
+        status: "noop",
+        walletBalance: wallet?.balance ?? 0,
+      };
+    }
+
+    const wallet = await getDefaultWallet({
+      prisma: nestedTransaction(tx),
+      guildId: voiceSession.guildId,
+      userId: voiceSession.userId,
+      currencyId,
+    });
+    const updatedWallet = await tx.wallet.update({
+      where: { id: wallet.id },
+      data: { balance: { increment: awardedUnits } },
+    });
+    const transaction = await tx.transaction.create({
+      data: {
+        walletId: wallet.id,
+        amount: awardedUnits,
+        reason: `Birthday 2026 voice activity: day ${eventDayIndex}, session ${voiceSession.id}`,
+        transactionType: "add",
+        entryType: "credit",
+        createdAt: voiceSession.leftAt,
+      },
+    });
+    await tx.birthday2026PersonalTransaction.create({
+      data: {
+        configId: config.id,
+        userId: voiceSession.userId,
+        transactionId: transaction.id,
+        source: "voiceActivity",
+        sourceKey,
+        createdAt: voiceSession.leftAt,
+      },
+    });
+
+    return {
+      ok: true,
+      awardedUnits,
+      dailyAwardedUnits: dailyState.awardedUnits,
+      eligibleSeconds,
+      eventDayIndex,
+      status: "awarded",
+      walletBalance: updatedWallet.balance,
+    };
+  });
+};

--- a/apps/bot/src/events/birthday2026/voiceEarningService.ts
+++ b/apps/bot/src/events/birthday2026/voiceEarningService.ts
@@ -4,8 +4,12 @@ import type {
   PrismaTransaction,
 } from "@hashira/db";
 import { nestedTransaction } from "@hashira/db/transaction";
-import { getDefaultWallet } from "../../economy/managers/walletManager";
-import { getBirthday2026EventDayIndex, getBirthday2026EventState } from "./eventState";
+import { addBalance } from "../../economy/managers/transferManager";
+import {
+  getBirthday2026EventDayIndex,
+  getBirthday2026EventState,
+  MILLISECONDS_PER_EVENT_DAY,
+} from "./eventState";
 
 export type ConfigureBirthday2026VoiceEarningResult =
   | { ok: true; config: Birthday2026VoiceEarningConfig }
@@ -187,8 +191,10 @@ export const awardBirthday2026VoicePasza = async (
   if (eventDayIndex === null) {
     return { ok: false, reason: "event_not_open" };
   }
-  const dayStart = new Date(config.eventStartAt.getTime() + eventDayIndex * 86_400_000);
-  const dayEnd = new Date(dayStart.getTime() + 86_400_000);
+  const dayStart = new Date(
+    config.eventStartAt.getTime() + eventDayIndex * MILLISECONDS_PER_EVENT_DAY,
+  );
+  const dayEnd = new Date(dayStart.getTime() + MILLISECONDS_PER_EVENT_DAY);
   const eligibleTime = await prisma.voiceSessionTotal.aggregate({
     where: {
       isAlone: false,
@@ -270,25 +276,13 @@ export const awardBirthday2026VoicePasza = async (
       };
     }
 
-    const wallet = await getDefaultWallet({
+    const { transaction, wallet } = await addBalance({
       prisma: nestedTransaction(tx),
       guildId: voiceSession.guildId,
-      userId: voiceSession.userId,
+      toUserId: voiceSession.userId,
+      amount: awardedUnits,
+      reason: `Birthday 2026 voice activity: day ${eventDayIndex}, session ${voiceSession.id}`,
       currencyId,
-    });
-    const updatedWallet = await tx.wallet.update({
-      where: { id: wallet.id },
-      data: { balance: { increment: awardedUnits } },
-    });
-    const transaction = await tx.transaction.create({
-      data: {
-        walletId: wallet.id,
-        amount: awardedUnits,
-        reason: `Birthday 2026 voice activity: day ${eventDayIndex}, session ${voiceSession.id}`,
-        transactionType: "add",
-        entryType: "credit",
-        createdAt: voiceSession.leftAt,
-      },
     });
     await tx.birthday2026PersonalTransaction.create({
       data: {
@@ -308,7 +302,7 @@ export const awardBirthday2026VoicePasza = async (
       eligibleSeconds,
       eventDayIndex,
       status: "awarded",
-      walletBalance: updatedWallet.balance,
+      walletBalance: wallet.balance,
     };
   });
 };

--- a/apps/bot/src/messageQueueBase.ts
+++ b/apps/bot/src/messageQueueBase.ts
@@ -20,6 +20,7 @@ import {
 import { Effect } from "effect";
 import { database } from "./db";
 import { digestBirthday2026FeedBatch } from "./events/birthday2026/economyService";
+import { awardBirthday2026VoicePasza } from "./events/birthday2026/voiceEarningService";
 import { sendCombatlog } from "./events/halloween2025/combatLogUtil";
 import {
   PrismaCombatRepository,
@@ -95,6 +96,10 @@ type Halloween2025EndSpawnData = {
 
 type Birthday2026DigestData = {
   batchId: number;
+};
+
+type Birthday2026VoiceAwardData = {
+  voiceSessionId: number;
 };
 
 export const messageQueueBase = new Hashira({ name: "messageQueueBase" })
@@ -489,6 +494,20 @@ export const messageQueueBase = new Hashira({ name: "messageQueueBase" })
             if (!result.ok && result.reason !== "batch_not_found") {
               throw new Error(
                 `Failed to digest Birthday 2026 feed batch ${batchId}: ${result.reason}`,
+              );
+            }
+          },
+        )
+        .addHandler(
+          "birthday2026VoiceAward",
+          async (_, { voiceSessionId }: Birthday2026VoiceAwardData) => {
+            const result = await awardBirthday2026VoicePasza(prisma, {
+              voiceSessionId,
+            });
+
+            if (!result.ok && result.reason !== "voice_session_not_found") {
+              console.warn(
+                `Birthday 2026 voice award skipped for session ${voiceSessionId}: ${result.reason}`,
               );
             }
           },

--- a/apps/bot/src/userActivity/userVoiceActivity.ts
+++ b/apps/bot/src/userActivity/userVoiceActivity.ts
@@ -1,27 +1,64 @@
 import { Hashira } from "@hashira/core";
+import type { ExtendedPrismaClient, PrismaTransaction, RedisClient } from "@hashira/db";
 import { base } from "../base";
-import { awardBirthday2026VoicePasza } from "../events/birthday2026/voiceEarningService";
 import { VoiceSessionManager } from "./voiceSessionManager";
 
 const createVoiceSessionManager = (
-  redis: ConstructorParameters<typeof VoiceSessionManager>[0],
-  prisma: ConstructorParameters<typeof VoiceSessionManager>[1],
+  redis: RedisClient,
+  prisma: ExtendedPrismaClient,
+  enqueueVoiceAward: (voiceSessionId: number, tx: PrismaTransaction) => Promise<void>,
+) => new VoiceSessionManager(redis, prisma, enqueueVoiceAward);
+
+const enqueueBirthday2026VoiceAward = (
+  messageQueue: {
+    push: (
+      type: "birthday2026VoiceAward",
+      data: { voiceSessionId: number },
+      delay?: number | Date,
+      identifier?: string,
+      tx?: PrismaTransaction,
+    ) => Promise<void>;
+  },
+  voiceSessionId: number,
+  tx: PrismaTransaction,
 ) =>
-  new VoiceSessionManager(redis, prisma, async (voiceSessionId) => {
-    await awardBirthday2026VoicePasza(prisma, { voiceSessionId });
-  });
+  messageQueue.push(
+    "birthday2026VoiceAward",
+    { voiceSessionId },
+    undefined,
+    `birthday2026VoiceAward:${voiceSessionId}`,
+    tx,
+  );
 
 export const userVoiceActivity = new Hashira({ name: "user-voice-activity" })
   .use(base)
-  .handle("guildAvailable", async ({ prisma, redis }, guild) => {
-    const sessionManager = createVoiceSessionManager(redis, prisma);
+  .handle("guildAvailable", async ({ messageQueue, prisma, redis }, guild) => {
+    const sessionManager = createVoiceSessionManager(
+      redis,
+      prisma,
+      (voiceSessionId, tx) =>
+        enqueueBirthday2026VoiceAward(messageQueue, voiceSessionId, tx),
+    );
     await sessionManager.handleNewGuild(guild);
   })
-  .handle("guildCreate", async ({ prisma, redis }, guild) => {
-    const sessionManager = createVoiceSessionManager(redis, prisma);
+  .handle("guildCreate", async ({ messageQueue, prisma, redis }, guild) => {
+    const sessionManager = createVoiceSessionManager(
+      redis,
+      prisma,
+      (voiceSessionId, tx) =>
+        enqueueBirthday2026VoiceAward(messageQueue, voiceSessionId, tx),
+    );
     await sessionManager.handleNewGuild(guild);
   })
-  .handle("voiceStateUpdate", async ({ prisma, redis }, oldState, newState) => {
-    const sessionManager = createVoiceSessionManager(redis, prisma);
-    await sessionManager.handleVoiceStateUpdate(oldState, newState);
-  });
+  .handle(
+    "voiceStateUpdate",
+    async ({ messageQueue, prisma, redis }, oldState, newState) => {
+      const sessionManager = createVoiceSessionManager(
+        redis,
+        prisma,
+        (voiceSessionId, tx) =>
+          enqueueBirthday2026VoiceAward(messageQueue, voiceSessionId, tx),
+      );
+      await sessionManager.handleVoiceStateUpdate(oldState, newState);
+    },
+  );

--- a/apps/bot/src/userActivity/userVoiceActivity.ts
+++ b/apps/bot/src/userActivity/userVoiceActivity.ts
@@ -1,18 +1,27 @@
 import { Hashira } from "@hashira/core";
 import { base } from "../base";
+import { awardBirthday2026VoicePasza } from "../events/birthday2026/voiceEarningService";
 import { VoiceSessionManager } from "./voiceSessionManager";
+
+const createVoiceSessionManager = (
+  redis: ConstructorParameters<typeof VoiceSessionManager>[0],
+  prisma: ConstructorParameters<typeof VoiceSessionManager>[1],
+) =>
+  new VoiceSessionManager(redis, prisma, async (voiceSessionId) => {
+    await awardBirthday2026VoicePasza(prisma, { voiceSessionId });
+  });
 
 export const userVoiceActivity = new Hashira({ name: "user-voice-activity" })
   .use(base)
   .handle("guildAvailable", async ({ prisma, redis }, guild) => {
-    const sessionManager = new VoiceSessionManager(redis, prisma);
+    const sessionManager = createVoiceSessionManager(redis, prisma);
     await sessionManager.handleNewGuild(guild);
   })
   .handle("guildCreate", async ({ prisma, redis }, guild) => {
-    const sessionManager = new VoiceSessionManager(redis, prisma);
+    const sessionManager = createVoiceSessionManager(redis, prisma);
     await sessionManager.handleNewGuild(guild);
   })
   .handle("voiceStateUpdate", async ({ prisma, redis }, oldState, newState) => {
-    const sessionManager = new VoiceSessionManager(redis, prisma);
+    const sessionManager = createVoiceSessionManager(redis, prisma);
     await sessionManager.handleVoiceStateUpdate(oldState, newState);
   });

--- a/apps/bot/src/userActivity/voiceSessionManager.ts
+++ b/apps/bot/src/userActivity/voiceSessionManager.ts
@@ -18,13 +18,21 @@ type RangeState = RangeUnion<0, 32>;
 const MAX_SESSION_DURATION = { minutes: 15 } as const satisfies Duration;
 const MAX_SESSION_DURATION_SECONDS = durationToSeconds(MAX_SESSION_DURATION);
 
+type VoiceSessionPersistedHandler = (voiceSessionId: number) => Promise<void>;
+
 export class VoiceSessionManager {
   private redis: RedisClient;
   private prisma: ExtendedPrismaClient;
+  private onVoiceSessionPersisted: VoiceSessionPersistedHandler | undefined;
 
-  constructor(redis: RedisClient, prisma: ExtendedPrismaClient) {
+  constructor(
+    redis: RedisClient,
+    prisma: ExtendedPrismaClient,
+    onVoiceSessionPersisted?: VoiceSessionPersistedHandler,
+  ) {
     this.redis = redis;
     this.prisma = prisma;
+    this.onVoiceSessionPersisted = onVoiceSessionPersisted;
   }
 
   private getSessionKey(guildId: string, userId: string): string {
@@ -291,8 +299,12 @@ export class VoiceSessionManager {
     );
 
     await ensureUserExists(this.prisma, state.id);
-    await this.prisma.voiceSession.create({ data: voiceSessionRecord });
+    const voiceSession = await this.prisma.voiceSession.create({
+      data: voiceSessionRecord,
+      select: { id: true },
+    });
     await this.redis.del(key);
+    await this.onVoiceSessionPersisted?.(voiceSession.id);
   }
 
   async handleVoiceState(voiceState: VoiceState): Promise<[string] | []> {
@@ -338,8 +350,12 @@ export class VoiceSessionManager {
       );
 
       await ensureUserExists(this.prisma, userId);
-      await this.prisma.voiceSession.create({ data: voiceSession });
+      const persistedSession = await this.prisma.voiceSession.create({
+        data: voiceSession,
+        select: { id: true },
+      });
       await this.redis.del(key);
+      await this.onVoiceSessionPersisted?.(persistedSession.id);
     } catch (error) {
       console.error(`Failed to process orphaned session ${key}:`, error);
     }

--- a/apps/bot/src/userActivity/voiceSessionManager.ts
+++ b/apps/bot/src/userActivity/voiceSessionManager.ts
@@ -1,4 +1,9 @@
-import type { ExtendedPrismaClient, Prisma, RedisClient } from "@hashira/db";
+import type {
+  ExtendedPrismaClient,
+  Prisma,
+  PrismaTransaction,
+  RedisClient,
+} from "@hashira/db";
 import { type RangeUnion, range } from "@hashira/utils/range";
 import { type Duration, differenceInSeconds } from "date-fns";
 import type { Guild, VoiceBasedChannel, VoiceState } from "discord.js";
@@ -18,16 +23,21 @@ type RangeState = RangeUnion<0, 32>;
 const MAX_SESSION_DURATION = { minutes: 15 } as const satisfies Duration;
 const MAX_SESSION_DURATION_SECONDS = durationToSeconds(MAX_SESSION_DURATION);
 
-type VoiceSessionPersistedHandler = (voiceSessionId: number) => Promise<void>;
+type VoiceSessionPersistedHandler = (
+  voiceSessionId: number,
+  tx: PrismaTransaction,
+) => Promise<void>;
 
 export class VoiceSessionManager {
   private redis: RedisClient;
   private prisma: ExtendedPrismaClient;
+  // TODO: this should be removed after the birthday2026 event is over, and the voice session data is no longer needed for that event
   private onVoiceSessionPersisted: VoiceSessionPersistedHandler | undefined;
 
   constructor(
     redis: RedisClient,
     prisma: ExtendedPrismaClient,
+
     onVoiceSessionPersisted?: VoiceSessionPersistedHandler,
   ) {
     this.redis = redis;
@@ -299,12 +309,14 @@ export class VoiceSessionManager {
     );
 
     await ensureUserExists(this.prisma, state.id);
-    const voiceSession = await this.prisma.voiceSession.create({
-      data: voiceSessionRecord,
-      select: { id: true },
+    await this.prisma.$transaction(async (tx) => {
+      const voiceSession = await tx.voiceSession.create({
+        data: voiceSessionRecord,
+        select: { id: true },
+      });
+      await this.onVoiceSessionPersisted?.(voiceSession.id, tx);
     });
     await this.redis.del(key);
-    await this.onVoiceSessionPersisted?.(voiceSession.id);
   }
 
   async handleVoiceState(voiceState: VoiceState): Promise<[string] | []> {
@@ -350,12 +362,14 @@ export class VoiceSessionManager {
       );
 
       await ensureUserExists(this.prisma, userId);
-      const persistedSession = await this.prisma.voiceSession.create({
-        data: voiceSession,
-        select: { id: true },
+      await this.prisma.$transaction(async (tx) => {
+        const persistedSession = await tx.voiceSession.create({
+          data: voiceSession,
+          select: { id: true },
+        });
+        await this.onVoiceSessionPersisted?.(persistedSession.id, tx);
       });
       await this.redis.del(key);
-      await this.onVoiceSessionPersisted?.(persistedSession.id);
     } catch (error) {
       console.error(`Failed to process orphaned session ${key}:`, error);
     }

--- a/apps/bot/test/birthday2026/voiceEarningService.database.test.ts
+++ b/apps/bot/test/birthday2026/voiceEarningService.database.test.ts
@@ -1,0 +1,380 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import { PrismaClient } from "@hashira/prisma-client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { upsertBirthday2026Config } from "../../src/events/birthday2026/configService";
+import { setupBirthday2026Economy } from "../../src/events/birthday2026/economyService";
+import {
+  assignBirthday2026Member,
+  createBirthday2026Team,
+} from "../../src/events/birthday2026/teamService";
+import {
+  awardBirthday2026VoicePasza,
+  configureBirthday2026VoiceEarning,
+  getBirthday2026VoiceEarningDiagnostics,
+} from "../../src/events/birthday2026/voiceEarningService";
+
+const connectionString = process.env.DATABASE_TEST_URL;
+const databaseTests = describe.skipIf(!connectionString);
+const prisma = connectionString
+  ? new PrismaClient({ adapter: new PrismaPg({ connectionString }) })
+  : null;
+
+const guildIds: string[] = [];
+const userIds: string[] = [];
+const currencyIds: number[] = [];
+const voiceSessionIds: number[] = [];
+
+const createFixture = async (dailyCap = 18, unitSeconds = 600) => {
+  if (!prisma) throw new Error("DATABASE_TEST_URL is required");
+
+  const suffix = crypto.randomUUID();
+  const guildId = `birthday-voice-guild-${suffix}`;
+  const actorUserId = `birthday-voice-actor-${suffix}`;
+  const memberUserId = `birthday-voice-member-${suffix}`;
+  const nonMemberUserId = `birthday-voice-non-member-${suffix}`;
+  guildIds.push(guildId);
+  userIds.push(actorUserId, memberUserId, nonMemberUserId);
+
+  await prisma.guild.create({ data: { id: guildId } });
+  await prisma.user.createMany({
+    data: [actorUserId, memberUserId, nonMemberUserId].map((id) => ({ id })),
+  });
+
+  const config = await upsertBirthday2026Config(prisma, {
+    guildId,
+    eventStartAt: new Date("2026-08-03T18:00:00Z"),
+    eventEndAt: new Date("2026-08-10T18:00:00Z"),
+    timezone: "Europe/Warsaw",
+    visible: true,
+    enabled: true,
+  });
+  if (!config.ok) throw new Error(config.reason);
+
+  const team = await createBirthday2026Team(prisma, {
+    guildId,
+    name: `Voice Team ${suffix}`,
+    roleId: `birthday-voice-role-${suffix}`,
+    color: 0x55aaff,
+  });
+  if (!team.ok) throw new Error(team.reason);
+
+  const assignment = await assignBirthday2026Member(prisma, {
+    guildId,
+    teamConfigId: team.team.id,
+    userId: memberUserId,
+  });
+  if (!assignment.ok) throw new Error(assignment.reason);
+
+  const economy = await setupBirthday2026Economy(prisma, {
+    guildId,
+    currencyName: `Pasza ${suffix}`,
+    currencySymbol: `P${suffix.slice(0, 6)}`,
+    digestionDelaySeconds: 14_400,
+    createdByUserId: actorUserId,
+  });
+  if (!economy.ok) throw new Error(economy.reason);
+  currencyIds.push(economy.currencyId);
+
+  const voiceEarning = await configureBirthday2026VoiceEarning(prisma, {
+    guildId,
+    unitSeconds,
+    dailyCap,
+  });
+  if (!voiceEarning.ok) throw new Error(voiceEarning.reason);
+
+  return {
+    config: config.config,
+    currencyId: economy.currencyId,
+    guildId,
+    memberUserId,
+    nonMemberUserId,
+  };
+};
+
+const createVoiceSession = async (input: {
+  guildId: string;
+  userId: string;
+  joinedAt: Date;
+  leftAt: Date;
+  totals: {
+    isAlone?: boolean;
+    isDeafened?: boolean;
+    isMuted?: boolean;
+    secondsSpent: number;
+  }[];
+}) => {
+  if (!prisma) throw new Error("DATABASE_TEST_URL is required");
+
+  const voiceSession = await prisma.voiceSession.create({
+    data: {
+      channelId: `voice-${crypto.randomUUID()}`,
+      guildId: input.guildId,
+      userId: input.userId,
+      joinedAt: input.joinedAt,
+      leftAt: input.leftAt,
+      totals: {
+        create: input.totals.map((total) => ({
+          isAlone: total.isAlone ?? false,
+          isDeafened: total.isDeafened ?? false,
+          isMuted: total.isMuted ?? false,
+          isStreaming: false,
+          isVideo: false,
+          secondsSpent: total.secondsSpent,
+        })),
+      },
+    },
+  });
+  voiceSessionIds.push(voiceSession.id);
+  return voiceSession;
+};
+
+databaseTests("Birthday 2026 voice earning", () => {
+  afterAll(async () => {
+    if (!prisma) return;
+
+    await prisma.birthday2026Config.deleteMany({
+      where: { guildId: { in: guildIds } },
+    });
+    await prisma.transaction.deleteMany({
+      where: { wallet: { currencyId: { in: currencyIds } } },
+    });
+    await prisma.wallet.deleteMany({ where: { currencyId: { in: currencyIds } } });
+    await prisma.currency.deleteMany({ where: { id: { in: currencyIds } } });
+    await prisma.voiceSessionTotal.deleteMany({
+      where: { voiceSessionId: { in: voiceSessionIds } },
+    });
+    await prisma.voiceSession.deleteMany({ where: { id: { in: voiceSessionIds } } });
+    await prisma.team.deleteMany({ where: { guildId: { in: guildIds } } });
+    await prisma.guild.deleteMany({ where: { id: { in: guildIds } } });
+    await prisma.user.deleteMany({ where: { id: { in: userIds } } });
+    await prisma.$disconnect();
+  });
+
+  it("configures voice earning idempotently and validates its values", async () => {
+    if (!prisma) throw new Error("DATABASE_TEST_URL is required");
+    const fixture = await createFixture();
+
+    expect(
+      await configureBirthday2026VoiceEarning(prisma, {
+        guildId: fixture.guildId,
+        unitSeconds: 600,
+        dailyCap: 18,
+      }),
+    ).toMatchObject({ ok: true, config: { unitSeconds: 600, dailyCap: 18 } });
+    expect(
+      await configureBirthday2026VoiceEarning(prisma, {
+        guildId: fixture.guildId,
+        unitSeconds: 0,
+        dailyCap: 18,
+      }),
+    ).toEqual({ ok: false, reason: "invalid_unit" });
+    expect(
+      await configureBirthday2026VoiceEarning(prisma, {
+        guildId: fixture.guildId,
+        unitSeconds: 600,
+        dailyCap: 0,
+      }),
+    ).toEqual({ ok: false, reason: "invalid_daily_cap" });
+  });
+
+  it("accumulates only eligible persisted seconds and awards completed units", async () => {
+    if (!prisma) throw new Error("DATABASE_TEST_URL is required");
+    const fixture = await createFixture();
+
+    const first = await createVoiceSession({
+      guildId: fixture.guildId,
+      userId: fixture.memberUserId,
+      joinedAt: new Date("2026-08-03T18:00:00Z"),
+      leftAt: new Date("2026-08-03T18:08:20Z"),
+      totals: [
+        { secondsSpent: 400 },
+        { isMuted: true, secondsSpent: 100 },
+        { isDeafened: true, secondsSpent: 100 },
+        { isAlone: true, secondsSpent: 100 },
+      ],
+    });
+    expect(
+      await awardBirthday2026VoicePasza(prisma, { voiceSessionId: first.id }),
+    ).toMatchObject({
+      ok: true,
+      awardedUnits: 0,
+      eligibleSeconds: 400,
+      status: "noop",
+    });
+
+    const second = await createVoiceSession({
+      guildId: fixture.guildId,
+      userId: fixture.memberUserId,
+      joinedAt: new Date("2026-08-03T18:10:00Z"),
+      leftAt: new Date("2026-08-03T18:13:20Z"),
+      totals: [{ secondsSpent: 200 }],
+    });
+    expect(
+      await awardBirthday2026VoicePasza(prisma, { voiceSessionId: second.id }),
+    ).toMatchObject({
+      ok: true,
+      awardedUnits: 1,
+      dailyAwardedUnits: 1,
+      eligibleSeconds: 600,
+      status: "awarded",
+      walletBalance: 1,
+    });
+    expect(
+      await awardBirthday2026VoicePasza(prisma, { voiceSessionId: second.id }),
+    ).toMatchObject({
+      ok: true,
+      awardedUnits: 0,
+      dailyAwardedUnits: 1,
+      status: "noop",
+      walletBalance: 1,
+    });
+
+    const third = await createVoiceSession({
+      guildId: fixture.guildId,
+      userId: fixture.memberUserId,
+      joinedAt: new Date("2026-08-03T18:20:00Z"),
+      leftAt: new Date("2026-08-03T18:40:00Z"),
+      totals: [{ secondsSpent: 1_200 }],
+    });
+    expect(
+      await awardBirthday2026VoicePasza(prisma, { voiceSessionId: third.id }),
+    ).toMatchObject({
+      ok: true,
+      awardedUnits: 2,
+      dailyAwardedUnits: 3,
+      eligibleSeconds: 1_800,
+      walletBalance: 3,
+    });
+
+    expect(
+      await getBirthday2026VoiceEarningDiagnostics(prisma, fixture.guildId),
+    ).toMatchObject({
+      awardedPasza: 3,
+      awardedTransactions: 2,
+      counterTotal: 3,
+      dailyRows: 1,
+      reconciled: true,
+    });
+    expect(
+      await configureBirthday2026VoiceEarning(prisma, {
+        guildId: fixture.guildId,
+        unitSeconds: 300,
+        dailyCap: 18,
+      }),
+    ).toEqual({ ok: false, reason: "voice_earning_already_used" });
+  });
+
+  it("enforces the daily cap across concurrent completed sessions", async () => {
+    if (!prisma) throw new Error("DATABASE_TEST_URL is required");
+    const fixture = await createFixture(2, 60);
+    const sessions = await Promise.all(
+      Array.from({ length: 3 }, (_, index) =>
+        createVoiceSession({
+          guildId: fixture.guildId,
+          userId: fixture.memberUserId,
+          joinedAt: new Date(
+            new Date("2026-08-03T18:00:00Z").getTime() + index * 120_000,
+          ),
+          leftAt: new Date(
+            new Date("2026-08-03T18:01:00Z").getTime() + index * 120_000,
+          ),
+          totals: [{ secondsSpent: 60 }],
+        }),
+      ),
+    );
+
+    await Promise.all(
+      sessions.map((session) =>
+        awardBirthday2026VoicePasza(prisma, { voiceSessionId: session.id }),
+      ),
+    );
+
+    const dailyState = await prisma.birthday2026DailyVoiceEarning.findUniqueOrThrow({
+      where: {
+        configId_userId_eventDayIndex: {
+          configId: fixture.config.id,
+          userId: fixture.memberUserId,
+          eventDayIndex: 0,
+        },
+      },
+    });
+    const awards = await prisma.birthday2026PersonalTransaction.findMany({
+      where: { configId: fixture.config.id, source: "voiceActivity" },
+      include: { transaction: true },
+    });
+    expect(dailyState.awardedUnits).toBe(2);
+    expect(awards.reduce((total, award) => total + award.transaction.amount, 0)).toBe(
+      2,
+    );
+  });
+
+  it("enforces event, membership, and join-time eligibility", async () => {
+    if (!prisma) throw new Error("DATABASE_TEST_URL is required");
+    const fixture = await createFixture();
+
+    const nonMember = await createVoiceSession({
+      guildId: fixture.guildId,
+      userId: fixture.nonMemberUserId,
+      joinedAt: new Date("2026-08-03T18:00:00Z"),
+      leftAt: new Date("2026-08-03T18:10:00Z"),
+      totals: [{ secondsSpent: 600 }],
+    });
+    expect(
+      await awardBirthday2026VoicePasza(prisma, { voiceSessionId: nonMember.id }),
+    ).toEqual({ ok: false, reason: "member_not_found" });
+
+    const beforeEvent = await createVoiceSession({
+      guildId: fixture.guildId,
+      userId: fixture.memberUserId,
+      joinedAt: new Date("2026-08-03T17:50:00Z"),
+      leftAt: new Date("2026-08-03T18:00:00Z"),
+      totals: [{ secondsSpent: 600 }],
+    });
+    expect(
+      await awardBirthday2026VoicePasza(prisma, { voiceSessionId: beforeEvent.id }),
+    ).toEqual({ ok: false, reason: "event_not_open" });
+
+    await prisma.birthday2026MemberState.update({
+      where: {
+        configId_userId: {
+          configId: fixture.config.id,
+          userId: fixture.memberUserId,
+        },
+      },
+      data: { joinedAt: new Date("2026-08-03T19:00:00Z") },
+    });
+    const beforeJoin = await createVoiceSession({
+      guildId: fixture.guildId,
+      userId: fixture.memberUserId,
+      joinedAt: new Date("2026-08-03T18:30:00Z"),
+      leftAt: new Date("2026-08-03T18:40:00Z"),
+      totals: [{ secondsSpent: 600 }],
+    });
+    expect(
+      await awardBirthday2026VoicePasza(prisma, { voiceSessionId: beforeJoin.id }),
+    ).toEqual({ ok: false, reason: "activity_before_join" });
+  });
+
+  it("resets the voice cap on the next event-anchored day", async () => {
+    if (!prisma) throw new Error("DATABASE_TEST_URL is required");
+    const fixture = await createFixture(1, 60);
+    const sessions = await Promise.all(
+      ["2026-08-03T18:00:00Z", "2026-08-04T18:00:00Z"].map((joinedAt) =>
+        createVoiceSession({
+          guildId: fixture.guildId,
+          userId: fixture.memberUserId,
+          joinedAt: new Date(joinedAt),
+          leftAt: new Date(new Date(joinedAt).getTime() + 60_000),
+          totals: [{ secondsSpent: 60 }],
+        }),
+      ),
+    );
+
+    const results = await Promise.all(
+      sessions.map((session) =>
+        awardBirthday2026VoicePasza(prisma, { voiceSessionId: session.id }),
+      ),
+    );
+    expect(results.map((result) => result.ok && result.awardedUnits)).toEqual([1, 1]);
+  });
+});

--- a/apps/bot/test/birthday2026/voiceEarningService.database.test.ts
+++ b/apps/bot/test/birthday2026/voiceEarningService.database.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, it } from "bun:test";
-import { PrismaClient } from "@hashira/prisma-client";
+import { PrismaClient } from "@hashira/db";
 import { PrismaPg } from "@prisma/adapter-pg";
 import { upsertBirthday2026Config } from "../../src/events/birthday2026/configService";
 import { setupBirthday2026Economy } from "../../src/events/birthday2026/economyService";

--- a/apps/bot/test/birthday2026/voiceEarningService.database.test.ts
+++ b/apps/bot/test/birthday2026/voiceEarningService.database.test.ts
@@ -64,6 +64,15 @@ const createFixture = async (dailyCap = 18, unitSeconds = 600) => {
     userId: memberUserId,
   });
   if (!assignment.ok) throw new Error(assignment.reason);
+  await prisma.birthday2026MemberState.update({
+    where: {
+      configId_userId: {
+        configId: config.config.id,
+        userId: memberUserId,
+      },
+    },
+    data: { joinedAt: new Date("2026-08-03T18:00:00Z") },
+  });
 
   const economy = await setupBirthday2026Economy(prisma, {
     guildId,

--- a/packages/db/prisma/migrations/20260731221205_add_birthday_2026_voice_earning/migration.sql
+++ b/packages/db/prisma/migrations/20260731221205_add_birthday_2026_voice_earning/migration.sql
@@ -1,0 +1,33 @@
+-- AlterEnum
+ALTER TYPE "Birthday2026PersonalTransactionSource" ADD VALUE 'voiceActivity';
+
+-- CreateTable
+CREATE TABLE "Birthday2026VoiceEarningConfig" (
+    "configId" INTEGER NOT NULL,
+    "unitSeconds" INTEGER NOT NULL,
+    "dailyCap" INTEGER NOT NULL,
+
+    CONSTRAINT "Birthday2026VoiceEarningConfig_pkey" PRIMARY KEY ("configId")
+);
+
+-- CreateTable
+CREATE TABLE "Birthday2026DailyVoiceEarning" (
+    "configId" INTEGER NOT NULL,
+    "userId" TEXT NOT NULL,
+    "eventDayIndex" INTEGER NOT NULL,
+    "awardedUnits" INTEGER NOT NULL,
+
+    CONSTRAINT "Birthday2026DailyVoiceEarning_pkey" PRIMARY KEY ("configId","userId","eventDayIndex")
+);
+
+-- CreateIndex
+CREATE INDEX "Birthday2026DailyVoiceEarning_userId_idx" ON "Birthday2026DailyVoiceEarning"("userId");
+
+-- AddForeignKey
+ALTER TABLE "Birthday2026VoiceEarningConfig" ADD CONSTRAINT "Birthday2026VoiceEarningConfig_configId_fkey" FOREIGN KEY ("configId") REFERENCES "Birthday2026Config"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Birthday2026DailyVoiceEarning" ADD CONSTRAINT "Birthday2026DailyVoiceEarning_configId_fkey" FOREIGN KEY ("configId") REFERENCES "Birthday2026VoiceEarningConfig"("configId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Birthday2026DailyVoiceEarning" ADD CONSTRAINT "Birthday2026DailyVoiceEarning_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/migrations/20260731221206_add_birthday_2026_voice_earning_checks/migration.sql
+++ b/packages/db/prisma/migrations/20260731221206_add_birthday_2026_voice_earning_checks/migration.sql
@@ -1,0 +1,13 @@
+-- Manual migration based off 20260731221205_add_birthday_2026_voice_earning.
+
+ALTER TABLE "Birthday2026VoiceEarningConfig"
+  ADD CONSTRAINT "Birthday2026VoiceEarningConfig_unit_seconds_valid"
+  CHECK ("unitSeconds" > 0),
+  ADD CONSTRAINT "Birthday2026VoiceEarningConfig_daily_cap_valid"
+  CHECK ("dailyCap" > 0);
+
+ALTER TABLE "Birthday2026DailyVoiceEarning"
+  ADD CONSTRAINT "Birthday2026DailyVoiceEarning_event_day_valid"
+  CHECK ("eventDayIndex" >= 0),
+  ADD CONSTRAINT "Birthday2026DailyVoiceEarning_awarded_units_valid"
+  CHECK ("awardedUnits" >= 0);

--- a/packages/db/prisma/models/birthday2026.prisma
+++ b/packages/db/prisma/models/birthday2026.prisma
@@ -12,6 +12,7 @@ model Birthday2026Config {
   guild                Guild                             @relation(fields: [guildId], references: [id], onDelete: Cascade)
   economy              Birthday2026EconomyConfig?
   textEarning          Birthday2026TextEarningConfig?
+  voiceEarning         Birthday2026VoiceEarningConfig?
   teams                Birthday2026TeamConfig[]
   feedBatches          Birthday2026FeedBatch[]
   personalTransactions Birthday2026PersonalTransaction[]
@@ -34,6 +35,15 @@ model Birthday2026TextEarningConfig {
   config           Birthday2026Config                @relation(fields: [configId], references: [id], onDelete: Cascade)
   disabledChannels Birthday2026DisabledTextChannel[]
   dailyStates      Birthday2026DailyTextEarning[]
+}
+
+model Birthday2026VoiceEarningConfig {
+  configId    Int @id
+  unitSeconds Int
+  dailyCap    Int
+
+  config      Birthday2026Config             @relation(fields: [configId], references: [id], onDelete: Cascade)
+  dailyStates Birthday2026DailyVoiceEarning[]
 }
 
 model Birthday2026TeamConfig {
@@ -106,6 +116,19 @@ model Birthday2026DailyTextEarning {
   @@index([userId])
 }
 
+model Birthday2026DailyVoiceEarning {
+  configId      Int
+  userId        String
+  eventDayIndex Int
+  awardedUnits  Int
+
+  config Birthday2026VoiceEarningConfig @relation(fields: [configId], references: [configId], onDelete: Cascade)
+  user   User                           @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@id([configId, userId, eventDayIndex])
+  @@index([userId])
+}
+
 model Birthday2026TeamWallet {
   id              Int      @id @default(autoincrement())
   teamConfigId    Int      @unique
@@ -171,6 +194,7 @@ enum Birthday2026PersonalTransactionSource {
   staffGrant
   feed
   textActivity
+  voiceActivity
 }
 
 enum Birthday2026TeamWalletTransactionSource {

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -177,6 +177,7 @@ model User {
   birthday2026CaptainOf             Birthday2026TeamIdentity[]         @relation("birthday2026Captain")
   birthday2026MemberStates          Birthday2026MemberState[]
   birthday2026DailyTextEarnings     Birthday2026DailyTextEarning[]
+  birthday2026DailyVoiceEarnings    Birthday2026DailyVoiceEarning[]
   birthday2026FeedBatches           Birthday2026FeedBatch[]            @relation("birthday2026FeedOwner")
   birthday2026PersonalTransactions  Birthday2026PersonalTransaction[]  @relation("birthday2026PersonalTransactionOwner")
   createdBirthday2026Transactions   Birthday2026PersonalTransaction[]  @relation("birthday2026PersonalTransactionCreator")


### PR DESCRIPTION
## Summary
- award Birthday 2026 Pasza from persisted eligible voice-session totals with event-day caps and idempotent accounting
- add admin voice configuration/diagnostics and expose voice awards in player history
- generate the Prisma schema migration and keep custom database checks in a separate follow-up migration
- update the implementation plan to mark voice earning implemented

## Tests
- `bun run typecheck`
- `bun prisma-check-migrations` against a fresh database
- `bun test` against a fresh database
- `bunx biome check` on changed source/test/docs files