### PR TITLE
fix(economy): make default wallet creation atomic

### DIFF
--- a/apps/bot/src/economy/managers/walletManager.ts
+++ b/apps/bot/src/economy/managers/walletManager.ts
@@ -1,4 +1,4 @@
-import type { ExtendedPrismaClient, Prisma, PrismaTransaction } from "@hashira/db";
+import type { ExtendedPrismaClient, PrismaTransaction } from "@hashira/db";
 import { GUILD_IDS, STRATA_CZASU_CURRENCY } from "../../specializedConstants";
 import {
   InsufficientBalanceError,
@@ -222,40 +222,39 @@ export const getDefaultWallets = async ({
 
     if (missingUserIds.length > 0) {
       const name = getDefaultWalletName(guildId);
-      const values = missingUserIds.map(
-        (userId) =>
-          ({
-            name,
-            userId,
-            guildId,
-            currencyId: currency.id,
-            default: true,
-          }) satisfies Prisma.WalletCreateManyInput,
-      );
-      await tx.wallet.createMany({ data: values, skipDuplicates: true });
 
-      const createdWallets = await tx.wallet.findMany({
-        where: {
-          userId: { in: missingUserIds },
+      await tx.wallet.createMany({
+        data: missingUserIds.map((userId) => ({
+          name,
+          userId,
           guildId,
           currencyId: currency.id,
           default: true,
-        },
+        })),
+        skipDuplicates: true,
       });
-      for (const wallet of createdWallets) walletsByUserId.set(wallet.userId, wallet);
+
+      const ensuredWallets = await tx.wallet.updateManyAndReturn({
+        where: {
+          userId: { in: missingUserIds },
+          name,
+          guildId,
+          currencyId: currency.id,
+        },
+        data: { default: true },
+      });
+
+      for (const wallet of ensuredWallets) walletsByUserId.set(wallet.userId, wallet);
     }
 
     const usersWithoutWallets = uniqueUserIds.filter(
       (userId) => !walletsByUserId.has(userId),
     );
+
     if (usersWithoutWallets.length > 0) {
       throw new WalletCreationError(usersWithoutWallets);
     }
 
-    return uniqueUserIds.map((userId) => {
-      const wallet = walletsByUserId.get(userId);
-      if (!wallet) throw new WalletCreationError([userId]);
-      return wallet;
-    });
+    return walletsByUserId.values().toArray();
   });
 };

--- a/apps/bot/src/economy/managers/walletManager.ts
+++ b/apps/bot/src/economy/managers/walletManager.ts
@@ -98,68 +98,6 @@ export const getReceivedTransfers = async ({
   return result._sum.amount ?? 0;
 };
 
-type CreateDefaultWalletsOptions = {
-  prisma: PrismaTransaction;
-  currencyId: number;
-  guildId: string;
-  userIds: string[];
-};
-
-const createDefaultWallets = async ({
-  prisma,
-  currencyId,
-  guildId,
-  userIds,
-}: CreateDefaultWalletsOptions) => {
-  const values = userIds.map(
-    (userId) =>
-      ({
-        name: getDefaultWalletName(guildId),
-        userId,
-        guildId,
-        currencyId,
-        default: true,
-      }) satisfies Prisma.WalletCreateManyInput,
-  );
-
-  const returnedUserIds = await prisma.wallet.createManyAndReturn({ data: values });
-
-  const usersWithoutWallets = userIds.filter(
-    (userId) => !returnedUserIds.some((wallet) => wallet.userId === userId),
-  );
-
-  if (returnedUserIds.length !== userIds.length)
-    throw new WalletCreationError(usersWithoutWallets);
-
-  return returnedUserIds;
-};
-
-type CreateDefaultWalletOptions = {
-  prisma: PrismaTransaction;
-  currencyId: number;
-  guildId: string;
-  userId: string;
-};
-
-const createDefaultWallet = async ({
-  prisma,
-  currencyId,
-  guildId,
-  userId,
-}: CreateDefaultWalletOptions) => {
-  const walletName = getDefaultWalletName(guildId);
-
-  return await prisma.wallet.create({
-    data: {
-      name: walletName,
-      userId,
-      guildId,
-      currencyId,
-      default: true,
-    },
-  });
-};
-
 type GetDefaultWalletOptions = {
   prisma: ExtendedPrismaClient;
   userId: string;
@@ -173,7 +111,7 @@ export const getDefaultWallet = async ({
   ...currencyOptions
 }: GetDefaultWalletOptions) => {
   return await prisma.$transaction(async (tx) => {
-    const currency = await getCurrency({ prisma: prisma, guildId, ...currencyOptions });
+    const currency = await getCurrency({ prisma: tx, guildId, ...currencyOptions });
 
     const wallet = await tx.wallet.findFirst({
       where: {
@@ -186,16 +124,25 @@ export const getDefaultWallet = async ({
 
     if (wallet) return wallet;
 
-    const [defaultWallet] = await createDefaultWallets({
-      prisma: tx,
-      currencyId: currency.id,
-      guildId,
-      userIds: [userId],
+    const name = getDefaultWalletName(guildId);
+    return await tx.wallet.upsert({
+      where: {
+        userId_name_guildId_currencyId: {
+          userId,
+          name,
+          guildId,
+          currencyId: currency.id,
+        },
+      },
+      create: {
+        name,
+        userId,
+        guildId,
+        currencyId: currency.id,
+        default: true,
+      },
+      update: { default: true },
     });
-
-    if (!defaultWallet) throw new WalletCreationError([userId]);
-
-    return defaultWallet;
   });
 };
 
@@ -213,33 +160,31 @@ export const getWallet = async ({
   walletName,
   ...currencyOptions
 }: GetWalletOptions) => {
+  if (!walletName) {
+    return await getDefaultWallet({
+      prisma,
+      userId,
+      guildId,
+      ...currencyOptions,
+    });
+  }
+
   return await prisma.$transaction(async (tx) => {
     const currency = await getCurrency({ prisma: tx, guildId, ...currencyOptions });
-    const walletCondition = walletName ? { name: walletName } : { default: true };
-
-    const wallet = await tx.wallet.findFirst({
+    const wallet = await tx.wallet.findUnique({
       where: {
-        userId,
-        guildId,
-        currencyId: currency.id,
-        ...walletCondition,
+        userId_name_guildId_currencyId: {
+          userId,
+          name: walletName,
+          guildId,
+          currencyId: currency.id,
+        },
       },
     });
 
     if (wallet) return wallet;
 
-    if (walletName) throw new WalletNotFoundError(walletName);
-
-    const defaultWallet = await createDefaultWallet({
-      prisma: tx,
-      currencyId: currency.id,
-      guildId,
-      userId: userId,
-    });
-
-    if (!defaultWallet) throw new WalletCreationError([userId]);
-
-    return defaultWallet;
+    throw new WalletNotFoundError(walletName);
   });
 };
 
@@ -256,32 +201,61 @@ export const getDefaultWallets = async ({
   ...currencyOptions
 }: GetDefaultWalletsOptions) => {
   return await prisma.$transaction(async (tx) => {
+    const uniqueUserIds = [...new Set(userIds)];
+    if (uniqueUserIds.length === 0) return [];
+
     const currency = await getCurrency({ prisma: tx, guildId, ...currencyOptions });
 
     const wallets = await tx.wallet.findMany({
       where: {
-        userId: { in: userIds },
+        userId: { in: uniqueUserIds },
         guildId,
         currencyId: currency.id,
         default: true,
       },
     });
+    const walletsByUserId = new Map(wallets.map((wallet) => [wallet.userId, wallet]));
 
-    if (wallets.length === userIds.length) return wallets;
-
-    const missingWallets = userIds.filter(
-      (userId) => !wallets.some((wallet) => wallet.userId === userId),
+    const missingUserIds = uniqueUserIds.filter(
+      (userId) => !walletsByUserId.has(userId),
     );
 
-    if (missingWallets.length === 0) return wallets;
+    if (missingUserIds.length > 0) {
+      const name = getDefaultWalletName(guildId);
+      const values = missingUserIds.map(
+        (userId) =>
+          ({
+            name,
+            userId,
+            guildId,
+            currencyId: currency.id,
+            default: true,
+          }) satisfies Prisma.WalletCreateManyInput,
+      );
+      await tx.wallet.createMany({ data: values, skipDuplicates: true });
 
-    const createdDefaultWallets = await createDefaultWallets({
-      prisma: tx,
-      currencyId: currency.id,
-      guildId,
-      userIds: missingWallets,
+      const createdWallets = await tx.wallet.findMany({
+        where: {
+          userId: { in: missingUserIds },
+          guildId,
+          currencyId: currency.id,
+          default: true,
+        },
+      });
+      for (const wallet of createdWallets) walletsByUserId.set(wallet.userId, wallet);
+    }
+
+    const usersWithoutWallets = uniqueUserIds.filter(
+      (userId) => !walletsByUserId.has(userId),
+    );
+    if (usersWithoutWallets.length > 0) {
+      throw new WalletCreationError(usersWithoutWallets);
+    }
+
+    return uniqueUserIds.map((userId) => {
+      const wallet = walletsByUserId.get(userId);
+      if (!wallet) throw new WalletCreationError([userId]);
+      return wallet;
     });
-
-    return [...wallets, ...createdDefaultWallets];
   });
 };

--- a/apps/bot/test/economy/walletConcurrency.test.ts
+++ b/apps/bot/test/economy/walletConcurrency.test.ts
@@ -8,10 +8,16 @@ import {
 import { purchaseShopItem } from "../../src/economy/managers/shopService";
 import {
   addBalance,
+  addBalances,
   transferBalance,
   transferBalances,
 } from "../../src/economy/managers/transferManager";
-import { debitWallet } from "../../src/economy/managers/walletManager";
+import {
+  debitWallet,
+  getDefaultWallet,
+  getDefaultWallets,
+  getWallet,
+} from "../../src/economy/managers/walletManager";
 
 const connectionString = process.env.DATABASE_TEST_URL;
 let prisma: PrismaClient;
@@ -73,7 +79,7 @@ const createWalletFixture = async (recipientCount: number, sourceBalance: number
 
 const walletDatabaseTests = describe.skipIf(!connectionString);
 
-walletDatabaseTests("wallet debit concurrency", () => {
+walletDatabaseTests("wallet concurrency", () => {
   beforeAll(() => {
     if (!connectionString) throw new Error("DATABASE_TEST_URL is required");
     prisma = new PrismaClient({ adapter: new PrismaPg({ connectionString }) });
@@ -139,6 +145,111 @@ walletDatabaseTests("wallet debit concurrency", () => {
     expect(source.balance).toBe(20);
     expect(recipients.map((wallet) => wallet.balance).sort()).toEqual([0, 80]);
     expect(transactions).toHaveLength(2);
+  });
+
+  it("returns one default wallet from concurrent single-wallet lookups", async () => {
+    const fixture = await createWalletFixture(0, 0);
+    await prisma.wallet.delete({ where: { id: fixture.sourceWallet.id } });
+
+    const wallets = await Promise.all([
+      getDefaultWallet({
+        prisma,
+        userId: fixture.sourceUserId,
+        guildId: fixture.guildId,
+        currencyId: fixture.currency.id,
+      }),
+      getWallet({
+        prisma,
+        userId: fixture.sourceUserId,
+        guildId: fixture.guildId,
+        currencyId: fixture.currency.id,
+      }),
+    ]);
+
+    expect(wallets[0]?.id).toBe(wallets[1]?.id);
+    expect(
+      await prisma.wallet.count({
+        where: {
+          userId: fixture.sourceUserId,
+          guildId: fixture.guildId,
+          currencyId: fixture.currency.id,
+          default: true,
+        },
+      }),
+    ).toBe(1);
+  });
+
+  it("preserves concurrent balance additions while creating one wallet", async () => {
+    const fixture = await createWalletFixture(1, 0);
+    const recipientUserId = getRequired(fixture.recipientUserIds[0]);
+    await prisma.wallet.delete({
+      where: { id: getRequired(fixture.recipientWallets[0]).id },
+    });
+
+    await Promise.all(
+      [10, 15].map((amount) =>
+        addBalance({
+          prisma,
+          toUserId: recipientUserId,
+          guildId: fixture.guildId,
+          currencyId: fixture.currency.id,
+          amount,
+          reason: "Concurrent wallet creation test",
+        }),
+      ),
+    );
+
+    const wallet = await prisma.wallet.findFirstOrThrow({
+      where: {
+        userId: recipientUserId,
+        guildId: fixture.guildId,
+        currencyId: fixture.currency.id,
+        default: true,
+      },
+    });
+    expect(wallet.balance).toBe(25);
+    expect(await prisma.transaction.count({ where: { walletId: wallet.id } })).toBe(2);
+  });
+
+  it("creates overlapping default-wallet batches exactly once", async () => {
+    const fixture = await createWalletFixture(2, 0);
+    await prisma.wallet.deleteMany({
+      where: { id: { in: fixture.recipientWallets.map((wallet) => wallet.id) } },
+    });
+    const firstRecipient = getRequired(fixture.recipientUserIds[0]);
+    const secondRecipient = getRequired(fixture.recipientUserIds[1]);
+
+    const [wallets] = await Promise.all([
+      getDefaultWallets({
+        prisma,
+        userIds: [firstRecipient, firstRecipient, secondRecipient],
+        guildId: fixture.guildId,
+        currencyId: fixture.currency.id,
+      }),
+      addBalances({
+        prisma,
+        toUserIds: [secondRecipient],
+        guildId: fixture.guildId,
+        currencyId: fixture.currency.id,
+        amount: 5,
+        reason: "Overlapping wallet batch test",
+      }),
+    ]);
+
+    expect(wallets).toHaveLength(2);
+    expect(new Set(wallets.map((wallet) => wallet.userId))).toEqual(
+      new Set([firstRecipient, secondRecipient]),
+    );
+    expect(
+      await prisma.wallet.count({
+        where: {
+          userId: { in: [firstRecipient, secondRecipient] },
+          guildId: fixture.guildId,
+          currencyId: fixture.currency.id,
+          default: true,
+        },
+      }),
+    ).toBe(2);
   });
 
   it("rolls the debit and its history entry back when a later write fails", async () => {


### PR DESCRIPTION
## Summary
- make single default-wallet creation atomic with Prisma `upsert` on the existing compound unique key
- route the default branch of `getWallet` through the same atomic path
- make multi-user default-wallet creation deduplicated and conflict-safe, then read back the authoritative rows
- cover concurrent lookups, concurrent balance grants, and overlapping wallet batches

## Affected callers audited
- balance grants and transfers
- shop purchases and profile balance reads
- Strata and Halloween currency paths
- Birthday 2026 staff grants, text earning, and voice earning

All wallet creation in application code routes through `walletManager`; no separate read-then-create path remains.

## Tests
- `bun run typecheck`
- `bun test` against a fresh database (367 pass, 1 skip)