### PR TITLE
ci: optimize stacked pull request workflows

### DIFF
--- a/.github/workflows/docker-build-test.yml
+++ b/.github/workflows/docker-build-test.yml
@@ -3,11 +3,21 @@ name: Docker Build Test
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   REGISTRY: ghcr.io
 
 jobs:
   build:
+    if: >-
+      ${{ github.event.pull_request.stack == null ||
+      github.event.pull_request.stack.base.ref ==
+      github.event.pull_request.base.ref ||
+      github.event.pull_request.stack.position ==
+      github.event.pull_request.stack.size }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/.github/workflows/lint-and-test.yml
+++ b/.github/workflows/lint-and-test.yml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   BUN_VERSION: 1.3.10
   DATABASE_URL: postgres://postgres:postgres@localhost:5432/postgres
@@ -37,7 +41,13 @@ jobs:
       - name: Check Formatting
         run: bunx biome format .
 
+  # Type and migration checks run on the top PR; tests also cover the bottom PR.
   types:
+    if: >-
+      ${{ github.event_name != 'pull_request' ||
+      github.event.pull_request.stack == null ||
+      github.event.pull_request.stack.position ==
+      github.event.pull_request.stack.size }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -51,6 +61,11 @@ jobs:
         run: bun typecheck
 
   migrations:
+    if: >-
+      ${{ github.event_name != 'pull_request' ||
+      github.event.pull_request.stack == null ||
+      github.event.pull_request.stack.position ==
+      github.event.pull_request.stack.size }}
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -76,6 +91,13 @@ jobs:
         run: bun prisma-check-migrations
 
   test:
+    if: >-
+      ${{ github.event_name != 'pull_request' ||
+      github.event.pull_request.stack == null ||
+      github.event.pull_request.stack.base.ref ==
+      github.event.pull_request.base.ref ||
+      github.event.pull_request.stack.position ==
+      github.event.pull_request.stack.size }}
     runs-on: ubuntu-latest
     services:
       postgres:

--- a/.github/workflows/pr-title-validation.yml
+++ b/.github/workflows/pr-title-validation.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate-pr-title:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Use stacked pull request metadata to avoid redundant expensive CI runs.
- Run tests and Docker builds on both the bottommost unmerged PR and the top PR.
- Keep type and migration checks on the top PR, while lint, formatting, and title validation run on every PR.
- Cancel obsolete runs for the same PR when new commits are pushed.

## Why

Stacked pull requests otherwise run the full workflow independently at every layer. The top PR contains the complete stack, while the bottommost unmerged PR validates the next change that can merge independently.

## Validation

- `git diff --check`
- Pre-commit hook passed
- Pre-push type-check passed