### PR TITLE
feat(birthday2026): feed Tucznik via modal with one-time cross-team feed

### DIFF
--- a/apps/bot/src/events/birthday2026/economyService.ts
+++ b/apps/bot/src/events/birthday2026/economyService.ts
@@ -283,7 +283,6 @@ export type FeedBirthday2026PigInput = {
   acceptedAt: Date;
   reason: string;
   scheduleDigestion: ScheduleBirthday2026Digestion;
-  /** The team whose Tucznik receives the Pasza. */
   targetTeamConfigId: number;
 };
 
@@ -301,16 +300,6 @@ export type FeedBirthday2026PigResult =
       reason: Birthday2026EconomyErrorReason;
     };
 
-type ResolveBirthday2026FeedTargetResult =
-  | { ok: true; teamConfigId: number; walletId: number }
-  | {
-      ok: false;
-      reason:
-        | "cross_feed_already_used"
-        | "target_team_not_found"
-        | "team_wallet_not_found";
-    };
-
 const resolveBirthday2026FeedTarget = async (
   tx: PrismaTransaction,
   input: {
@@ -321,15 +310,15 @@ const resolveBirthday2026FeedTarget = async (
     targetTeamConfigId: number;
     userId: string;
   },
-): Promise<ResolveBirthday2026FeedTargetResult> => {
+) => {
   const { configId, currencyId, ownTeamId, ownWallet, targetTeamConfigId, userId } =
     input;
 
   if (targetTeamConfigId === ownTeamId) {
     if (!ownWallet || ownWallet.currencyId !== currencyId) {
-      return { ok: false, reason: "team_wallet_not_found" };
+      return { ok: false, reason: "team_wallet_not_found" } as const;
     }
-    return { ok: true, teamConfigId: ownTeamId, walletId: ownWallet.id };
+    return { ok: true, teamConfigId: ownTeamId, walletId: ownWallet.id } as const;
   }
 
   const existingCrossFeed = await tx.birthday2026FeedBatch.findFirst({
@@ -341,7 +330,7 @@ const resolveBirthday2026FeedTarget = async (
     select: { id: true },
   });
   if (existingCrossFeed) {
-    return { ok: false, reason: "cross_feed_already_used" };
+    return { ok: false, reason: "cross_feed_already_used" } as const;
   }
 
   const targetTeam = await tx.birthday2026TeamConfig.findFirst({
@@ -349,13 +338,13 @@ const resolveBirthday2026FeedTarget = async (
     include: { wallet: true },
   });
   if (!targetTeam?.wallet || targetTeam.wallet.currencyId !== currencyId) {
-    return { ok: false, reason: "target_team_not_found" };
+    return { ok: false, reason: "target_team_not_found" } as const;
   }
   return {
     ok: true,
     teamConfigId: targetTeam.id,
     walletId: targetTeam.wallet.id,
-  };
+  } as const;
 };
 
 const findFeedResult = async (

--- a/apps/bot/src/events/birthday2026/economyService.ts
+++ b/apps/bot/src/events/birthday2026/economyService.ts
@@ -1,5 +1,6 @@
 import type {
   Birthday2026FeedBatch,
+  Birthday2026TeamWallet,
   ExtendedPrismaClient,
   PrismaTransaction,
 } from "@hashira/db";
@@ -22,6 +23,8 @@ export type Birthday2026EconomyErrorReason =
   | "invalid_digestion_delay"
   | "insufficient_balance"
   | "member_not_found"
+  | "cross_feed_already_used"
+  | "target_team_not_found"
   | "team_wallet_not_found";
 
 export type SetupBirthday2026EconomyResult =
@@ -280,6 +283,8 @@ export type FeedBirthday2026PigInput = {
   acceptedAt: Date;
   reason: string;
   scheduleDigestion: ScheduleBirthday2026Digestion;
+  /** The team whose Tucznik receives the Pasza. */
+  targetTeamConfigId: number;
 };
 
 export type FeedBirthday2026PigResult =
@@ -295,6 +300,63 @@ export type FeedBirthday2026PigResult =
       ok: false;
       reason: Birthday2026EconomyErrorReason;
     };
+
+type ResolveBirthday2026FeedTargetResult =
+  | { ok: true; teamConfigId: number; walletId: number }
+  | {
+      ok: false;
+      reason:
+        | "cross_feed_already_used"
+        | "target_team_not_found"
+        | "team_wallet_not_found";
+    };
+
+const resolveBirthday2026FeedTarget = async (
+  tx: PrismaTransaction,
+  input: {
+    configId: number;
+    currencyId: number;
+    ownTeamId: number;
+    ownWallet: Birthday2026TeamWallet | null;
+    targetTeamConfigId: number;
+    userId: string;
+  },
+): Promise<ResolveBirthday2026FeedTargetResult> => {
+  const { configId, currencyId, ownTeamId, ownWallet, targetTeamConfigId, userId } =
+    input;
+
+  if (targetTeamConfigId === ownTeamId) {
+    if (!ownWallet || ownWallet.currencyId !== currencyId) {
+      return { ok: false, reason: "team_wallet_not_found" };
+    }
+    return { ok: true, teamConfigId: ownTeamId, walletId: ownWallet.id };
+  }
+
+  const existingCrossFeed = await tx.birthday2026FeedBatch.findFirst({
+    where: {
+      configId,
+      userId,
+      wallet: { teamConfigId: { not: ownTeamId } },
+    },
+    select: { id: true },
+  });
+  if (existingCrossFeed) {
+    return { ok: false, reason: "cross_feed_already_used" };
+  }
+
+  const targetTeam = await tx.birthday2026TeamConfig.findFirst({
+    where: { id: targetTeamConfigId, configId },
+    include: { wallet: true },
+  });
+  if (!targetTeam?.wallet || targetTeam.wallet.currencyId !== currencyId) {
+    return { ok: false, reason: "target_team_not_found" };
+  }
+  return {
+    ok: true,
+    teamConfigId: targetTeam.id,
+    walletId: targetTeam.wallet.id,
+  };
+};
 
 const findFeedResult = async (
   prisma: PrismaTransaction,
@@ -360,10 +422,6 @@ export const feedBirthday2026Pig = async (
     },
   });
   if (!membership) return { ok: false, reason: "member_not_found" };
-  const teamWallet = membership.teamConfig.wallet;
-  if (!teamWallet || teamWallet.currencyId !== currencyId) {
-    return { ok: false, reason: "team_wallet_not_found" };
-  }
 
   try {
     return await prisma.$transaction(async (tx) => {
@@ -372,6 +430,17 @@ export const feedBirthday2026Pig = async (
       if (!state.enabled) {
         return { ok: false, reason: "event_not_open" };
       }
+
+      const target = await resolveBirthday2026FeedTarget(tx, {
+        configId: config.id,
+        userId: input.userId,
+        currencyId,
+        targetTeamConfigId: input.targetTeamConfigId,
+        ownTeamId: membership.teamConfigId,
+        ownWallet: membership.teamConfig.wallet,
+      });
+      if (!target.ok) return target;
+
       const wallet = await getDefaultWallet({
         prisma: nestedTransaction(tx),
         guildId: input.guildId,
@@ -402,7 +471,7 @@ export const feedBirthday2026Pig = async (
       const batch = await tx.birthday2026FeedBatch.create({
         data: {
           configId: config.id,
-          walletId: teamWallet.id,
+          walletId: target.walletId,
           userId: input.userId,
           personalTransactionId: personalTransaction.id,
           amount: input.amount,
@@ -412,12 +481,12 @@ export const feedBirthday2026Pig = async (
         },
       });
       const updatedTeamWallet = await tx.birthday2026TeamWallet.update({
-        where: { id: teamWallet.id },
+        where: { id: target.walletId },
         data: { balance: { increment: input.amount } },
       });
       await tx.birthday2026TeamWalletTransaction.create({
         data: {
-          walletId: teamWallet.id,
+          walletId: target.walletId,
           feedBatchId: batch.id,
           personalTransactionId: personalTransaction.id,
           source: "feed",
@@ -439,7 +508,7 @@ export const feedBirthday2026Pig = async (
         batch,
         personalBalance: updatedPersonalWallet.balance,
         teamBalance: updatedTeamWallet.balance,
-        teamConfigId: membership.teamConfigId,
+        teamConfigId: target.teamConfigId,
       };
     });
   } catch (error) {

--- a/apps/bot/src/events/birthday2026/index.ts
+++ b/apps/bot/src/events/birthday2026/index.ts
@@ -70,6 +70,7 @@ import {
   BIRTHDAY_2026_FEED_MODAL_CUSTOM_ID_PREFIX,
   BIRTHDAY_2026_FEED_TEAM_BUTTON_CUSTOM_ID_PREFIX,
   buildBirthday2026BalanceView,
+  buildBirthday2026CrossFeedAnnouncementView,
   buildBirthday2026FeedResultView,
   buildBirthday2026InfoView,
   buildBirthday2026RankingView,
@@ -333,13 +334,13 @@ const announceBirthday2026CrossFeed = async (
       encounterConfig: { select: { channelId: true } },
       teams: {
         where: { id: targetTeamConfigId },
-        select: { roleId: true },
+        select: { roleId: true, color: true },
       },
     },
   });
   const channelId = config?.encounterConfig?.channelId;
-  const targetRoleId = config?.teams[0]?.roleId;
-  if (!channelId || !targetRoleId) return;
+  const targetTeam = config?.teams[0];
+  if (!channelId || !targetTeam) return;
 
   const channel = await client.channels.fetch(channelId);
   if (!channel) return;
@@ -347,11 +348,14 @@ const announceBirthday2026CrossFeed = async (
   if (!channel.isSendable()) return;
 
   await channel.send(
-    `🚨 Wykryto przypadek niezgodzentia z polityką firmy!\n\n` +
-      `Pracownik <@${userId}> został przyłapany na **dokarmianiu cudzej świni** – ` +
-      `przekazał ${amount} Paszy do koryta drużyny <@&${targetRoleId}>.\n\n` +
-      `Dział prawny prosi o nieużywanie wyrażenia "katastrofa biologiczna" ` +
-      `do czasu zakończenia postępowania.`,
+    render(
+      buildBirthday2026CrossFeedAnnouncementView({
+        userId,
+        amount,
+        targetRoleId: targetTeam.roleId,
+        accentColor: targetTeam.color,
+      }),
+    ),
   );
 };
 

--- a/apps/bot/src/events/birthday2026/index.ts
+++ b/apps/bot/src/events/birthday2026/index.ts
@@ -286,6 +286,17 @@ const runBirthday2026FeedModal = async (
   }
   await updateBirthday2026Status(itx.client, prisma, result.teamConfigId);
 
+  if (targetTeamConfigId !== ownTeamId) {
+    await announceBirthday2026CrossFeed(
+      itx.client,
+      prisma,
+      itx.guildId,
+      itx.user.id,
+      result.batch.amount,
+      targetTeamConfigId,
+    );
+  }
+
   const after = await getBirthday2026PlayerSnapshot(
     prisma,
     itx.guildId,
@@ -305,6 +316,42 @@ const runBirthday2026FeedModal = async (
         targetTeamConfigId,
       ),
     ),
+  );
+};
+
+const announceBirthday2026CrossFeed = async (
+  client: Client,
+  prisma: ExtendedPrismaClient,
+  guildId: string,
+  userId: string,
+  amount: number,
+  targetTeamConfigId: number,
+) => {
+  const config = await prisma.birthday2026Config.findUnique({
+    where: { guildId },
+    include: {
+      encounterConfig: { select: { channelId: true } },
+      teams: {
+        where: { id: targetTeamConfigId },
+        select: { roleId: true },
+      },
+    },
+  });
+  const channelId = config?.encounterConfig?.channelId;
+  const targetRoleId = config?.teams[0]?.roleId;
+  if (!channelId || !targetRoleId) return;
+
+  const channel = await client.channels.fetch(channelId);
+  if (!channel) return;
+  if (channel.isDMBased()) return;
+  if (!channel.isSendable()) return;
+
+  await channel.send(
+    `🚨 Wykryto przypadek niezgodzentia z polityką firmy!\n\n` +
+      `Pracownik <@${userId}> został przyłapany na **dokarmianiu cudzej świni** – ` +
+      `przekazał ${amount} Paszy do koryta drużyny <@&${targetRoleId}>.\n\n` +
+      `Dział prawny prosi o nieużywanie wyrażenia "katastrofa biologiczna" ` +
+      `do czasu zakończenia postępowania.`,
   );
 };
 

--- a/apps/bot/src/events/birthday2026/index.ts
+++ b/apps/bot/src/events/birthday2026/index.ts
@@ -2,18 +2,27 @@ import { Hashira } from "@hashira/core";
 import type { ExtendedPrismaClient, PrismaTransaction } from "@hashira/db";
 import { render } from "@hashira/jsx";
 import {
+  ActionRowBuilder,
+  type ButtonInteraction,
   bold,
+  type ChatInputCommandInteraction,
   type Client,
   channelMention,
+  DiscordjsErrorCodes,
   type Guild,
+  type ModalActionRowComponentBuilder,
+  ModalBuilder,
   PermissionFlagsBits,
   type RepliableInteraction,
   roleMention,
+  TextInputBuilder,
+  TextInputStyle,
   TimestampStyles,
   time,
   userMention,
 } from "discord.js";
 import { base } from "../../base";
+import { discordTry } from "../../util/discordTry";
 import { ensureUserExists } from "../../util/ensureUsersExist";
 import { errorFollowUp } from "../../util/errorFollowUp";
 import { getColor } from "../../util/getColor";
@@ -28,6 +37,7 @@ import {
   feedBirthday2026Pig,
   getBirthday2026EconomyStatus,
   grantBirthday2026Pasza,
+  type ScheduleBirthday2026Digestion,
   setupBirthday2026Economy,
 } from "./economyService";
 import {
@@ -56,6 +66,9 @@ import {
 } from "./playerService";
 import {
   BIRTHDAY_2026_FEED_ALL_CUSTOM_ID,
+  BIRTHDAY_2026_FEED_AMOUNT_CUSTOM_ID,
+  BIRTHDAY_2026_FEED_MODAL_CUSTOM_ID_PREFIX,
+  BIRTHDAY_2026_FEED_TEAM_BUTTON_CUSTOM_ID_PREFIX,
   buildBirthday2026BalanceView,
   buildBirthday2026FeedResultView,
   buildBirthday2026InfoView,
@@ -132,6 +145,9 @@ const economyErrorMessages = {
   invalid_currency: "Nazwa i symbol waluty nie mogą być puste.",
   invalid_digestion_delay: "Czas trawienia musi być nieujemną liczbą sekund.",
   member_not_found: "Ten użytkownik nie należy do eventu.",
+  target_team_not_found: "Nie znaleziono drużyny, do której chcesz przekazać Paszę.",
+  cross_feed_already_used:
+    "Możesz przypadkowo nakarmić drużynę tylko raz podczas całego eventu.",
   team_wallet_not_found: "Drużyna nie ma poprawnie skonfigurowanego portfela.",
 } satisfies Record<Birthday2026EconomyErrorReason, string>;
 
@@ -181,6 +197,116 @@ const getPlayerSnapshotOrReply = async (
   }
   return result.snapshot;
 };
+
+const runBirthday2026FeedModal = async (
+  itx: ChatInputCommandInteraction<"cached"> | ButtonInteraction<"cached">,
+  prisma: ExtendedPrismaClient,
+  scheduleDigestion: ScheduleBirthday2026Digestion,
+  targetTeamConfigId: number,
+) => {
+  const before = await getBirthday2026PlayerSnapshot(
+    prisma,
+    itx.guildId,
+    itx.user.id,
+    itx.createdAt,
+  );
+  if (!before.ok) {
+    await errorFollowUp(itx, publicErrorMessages[before.reason]);
+    return;
+  }
+  if (!before.snapshot.membership) {
+    await errorFollowUp(itx, playerFeedErrorMessages.member_not_found);
+    return;
+  }
+
+  const modalCustomId = `${BIRTHDAY_2026_FEED_MODAL_CUSTOM_ID_PREFIX}:${targetTeamConfigId}:${itx.id}:${itx.user.id}`;
+  const modal = new ModalBuilder()
+    .setCustomId(modalCustomId)
+    .setTitle("🥣 Nakarm Tucznika")
+    .addComponents(
+      new ActionRowBuilder<ModalActionRowComponentBuilder>().addComponents(
+        new TextInputBuilder()
+          .setCustomId(BIRTHDAY_2026_FEED_AMOUNT_CUSTOM_ID)
+          .setLabel(
+            `Ilość Paszy (masz: ${before.snapshot.balance} ${before.snapshot.currencySymbol})`,
+          )
+          .setPlaceholder("0")
+          .setMinLength(1)
+          .setMaxLength(9)
+          .setRequired(true)
+          .setValue(String(before.snapshot.balance))
+          .setStyle(TextInputStyle.Short),
+      ),
+    );
+  await itx.showModal(modal);
+
+  const submitItx = await discordTry(
+    () =>
+      itx.awaitModalSubmit({
+        time: 60_000 * 3,
+        filter: (submitted) => submitted.customId === modalCustomId,
+      }),
+    [DiscordjsErrorCodes.InteractionCollectorError],
+    () => null,
+  );
+  if (!submitItx) return;
+
+  await submitItx.deferReply({ flags: "Ephemeral" });
+
+  const rawAmount = submitItx.fields
+    .getTextInputValue(BIRTHDAY_2026_FEED_AMOUNT_CUSTOM_ID)
+    .trim();
+  const amount = Number(rawAmount);
+  if (!Number.isSafeInteger(amount) || amount < 1) {
+    await errorFollowUp(submitItx, "Podaj poprawną liczbę Paszy.");
+    return;
+  }
+  if (amount > before.snapshot.balance) {
+    await errorFollowUp(submitItx, playerFeedErrorMessages.insufficient_balance);
+    return;
+  }
+
+  const ownTeamId = before.snapshot.membership.teamConfigId;
+  const result = await feedBirthday2026Player(prisma, {
+    guildId: itx.guildId,
+    userId: itx.user.id,
+    amount,
+    sourceKey: submitItx.id,
+    acceptedAt: submitItx.createdAt,
+    reason:
+      targetTeamConfigId === ownTeamId
+        ? "Birthday 2026 player feed"
+        : "Birthday 2026 cross-team feed",
+    targetTeamConfigId,
+    scheduleDigestion,
+  });
+  if (!result.ok) {
+    await errorFollowUp(submitItx, playerFeedErrorMessages[result.reason]);
+    return;
+  }
+  await updateBirthday2026Status(itx.client, prisma, result.teamConfigId);
+
+  const after = await getBirthday2026PlayerSnapshot(
+    prisma,
+    itx.guildId,
+    itx.user.id,
+    submitItx.createdAt,
+  );
+  if (!after.ok) {
+    await errorFollowUp(submitItx, publicErrorMessages[after.reason]);
+    return;
+  }
+  await submitItx.editReply(
+    render(
+      buildBirthday2026FeedResultView(
+        after.snapshot,
+        result.batch.amount,
+        result.batch.digestAt,
+      ),
+    ),
+  );
+};
+
 const findTeamByRole = async (
   prisma: PrismaTransaction,
   guildId: string,
@@ -332,22 +458,29 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
       .addCommand("nakarm", (command) =>
         command
           .setDescription("Przekaż Paszę Tucznikowi swojej drużyny")
-          .addInteger("ilosc", (option) =>
-            option.setDescription("Ilość Paszy").setMinValue(1),
-          )
-          .handle(async ({ prisma, messageQueue }, { ilosc: amount }, itx) => {
+          .handle(async ({ prisma, messageQueue }, _, itx) => {
             if (!itx.inCachedGuild()) return;
-            await itx.deferReply({ flags: "Ephemeral" });
             await ensureUserExists(prisma, itx.user);
 
-            const result = await feedBirthday2026Player(prisma, {
-              guildId: itx.guildId,
-              userId: itx.user.id,
-              amount,
-              sourceKey: itx.id,
-              acceptedAt: itx.createdAt,
-              reason: "Birthday 2026 player feed",
-              scheduleDigestion: (tx, batch) =>
+            const before = await getBirthday2026PlayerSnapshot(
+              prisma,
+              itx.guildId,
+              itx.user.id,
+              itx.createdAt,
+            );
+            if (!before.ok) {
+              await errorFollowUp(itx, publicErrorMessages[before.reason]);
+              return;
+            }
+            if (!before.snapshot.membership) {
+              await errorFollowUp(itx, playerFeedErrorMessages.member_not_found);
+              return;
+            }
+
+            await runBirthday2026FeedModal(
+              itx,
+              prisma,
+              (tx, batch) =>
                 messageQueue.push(
                   "birthday2026Digest",
                   { batchId: batch.id },
@@ -355,30 +488,7 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
                   batch.id.toString(),
                   tx,
                 ),
-            });
-            if (!result.ok) {
-              await errorFollowUp(itx, playerFeedErrorMessages[result.reason]);
-              return;
-            }
-            await updateBirthday2026Status(itx.client, prisma, result.teamConfigId);
-
-            const snapshot = await getPlayerSnapshotOrReply(
-              prisma,
-              itx.guildId,
-              itx.user.id,
-              itx.createdAt,
-              itx,
-            );
-            if (!snapshot) return;
-
-            await itx.editReply(
-              render(
-                buildBirthday2026FeedResultView(
-                  snapshot,
-                  result.batch.amount,
-                  result.batch.digestAt,
-                ),
-              ),
+              before.snapshot.membership.teamConfigId,
             );
           }),
       )
@@ -1342,6 +1452,18 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
               if (!itx.inCachedGuild()) return;
               await itx.deferReply({ flags: "Ephemeral" });
 
+              const memberState = await prisma.birthday2026MemberState.findFirst({
+                where: {
+                  userId: user.id,
+                  teamConfig: { config: { guildId: itx.guildId } },
+                },
+                select: { teamConfigId: true },
+              });
+              if (!memberState) {
+                await errorFollowUp(itx, economyErrorMessages.member_not_found);
+                return;
+              }
+
               const result = await feedBirthday2026Pig(prisma, {
                 guildId: itx.guildId,
                 userId: user.id,
@@ -1349,6 +1471,7 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
                 sourceKey: itx.id,
                 acceptedAt: itx.createdAt,
                 reason,
+                targetTeamConfigId: memberState.teamConfigId,
                 scheduleDigestion: (tx, batch) =>
                   messageQueue.push(
                     "birthday2026Digest",
@@ -1702,6 +1825,28 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
       await itx.editReply(replies[result.status]);
       return;
     }
+    if (
+      itx.customId.startsWith(`${BIRTHDAY_2026_FEED_TEAM_BUTTON_CUSTOM_ID_PREFIX}:`)
+    ) {
+      if (!itx.inCachedGuild()) return;
+      const targetTeamConfigId = Number(itx.customId.split(":").at(1));
+      if (!Number.isSafeInteger(targetTeamConfigId) || targetTeamConfigId <= 0) return;
+      await ensureUserExists(prisma, itx.user);
+      await runBirthday2026FeedModal(
+        itx,
+        prisma,
+        (tx, batch) =>
+          messageQueue.push(
+            "birthday2026Digest",
+            { batchId: batch.id },
+            batch.digestAt,
+            batch.id.toString(),
+            tx,
+          ),
+        targetTeamConfigId,
+      );
+      return;
+    }
     if (itx.customId !== BIRTHDAY_2026_FEED_ALL_CUSTOM_ID) return;
     if (!itx.inCachedGuild()) return;
 
@@ -1732,6 +1877,7 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
       sourceKey: itx.id,
       acceptedAt: itx.createdAt,
       reason: "Birthday 2026 player feed",
+      targetTeamConfigId: before.membership.teamConfigId,
       scheduleDigestion: (tx, batch) =>
         messageQueue.push(
           "birthday2026Digest",

--- a/apps/bot/src/events/birthday2026/index.ts
+++ b/apps/bot/src/events/birthday2026/index.ts
@@ -302,6 +302,7 @@ const runBirthday2026FeedModal = async (
         after.snapshot,
         result.batch.amount,
         result.batch.digestAt,
+        targetTeamConfigId,
       ),
     ),
   );
@@ -1908,6 +1909,7 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
           after,
           result.batch.amount,
           result.batch.digestAt,
+          before.membership.teamConfigId,
         ),
       ),
     );

--- a/apps/bot/src/events/birthday2026/playerView.tsx
+++ b/apps/bot/src/events/birthday2026/playerView.tsx
@@ -218,17 +218,37 @@ export const buildBirthday2026FeedResultView = (
   snapshot: Birthday2026PlayerSnapshot,
   amount: number,
   digestAt: Date,
+  targetTeamConfigId: number,
 ): JSXNode => {
   const team = findPlayerTeam(snapshot);
+  const isCrossFeed = targetTeamConfigId !== snapshot.membership?.teamConfigId;
+  const targetTeam = snapshot.teams.find((team) => team.id === targetTeamConfigId);
   const canFeedAgain = snapshot.balance > 0 && snapshot.eventState === "open";
 
   return (
-    <Container accentColor={team?.color ?? 0xf5a623}>
+    <Container
+      accentColor={
+        isCrossFeed ? (targetTeam?.color ?? 0xf5a623) : (team?.color ?? 0xf5a623)
+      }
+    >
       <TextDisplay>
-        <H1>🥣 Tucznik nakarmiony!</H1>
+        <H1>{isCrossFeed ? "😳 Oops, pomyłka!" : "🥣 Tucznik nakarmiony!"}</H1>
         <Br />
-        Przekazano <Bold>{formatPasza(amount, snapshot.currencySymbol)}</Bold> do koryta{" "}
-        {team ? roleMention(team.roleId) : "Twojej drużyny"}.
+        {isCrossFeed && targetTeam ? (
+          <>
+            Zamiast swojego Tucznika,{" "}
+            <Bold>{formatPasza(amount, snapshot.currencySymbol)}</Bold> trafiło do
+            koryta drużyny {roleMention(targetTeam.roleId)}!
+            <Br />
+            Takie przypadki zdarzają się tylko raz na cały event — nikt się nie dowie.
+            👀
+          </>
+        ) : (
+          <>
+            Przekazano <Bold>{formatPasza(amount, snapshot.currencySymbol)}</Bold> do
+            koryta Twojej drużyny.
+          </>
+        )}
         <Br />
         <Bold>Pozostałe saldo:</Bold>{" "}
         {formatPasza(snapshot.balance, snapshot.currencySymbol)}

--- a/apps/bot/src/events/birthday2026/playerView.tsx
+++ b/apps/bot/src/events/birthday2026/playerView.tsx
@@ -267,3 +267,26 @@ export const buildBirthday2026FeedResultView = (
     </Container>
   );
 };
+
+export const buildBirthday2026CrossFeedAnnouncementView = (input: {
+  userId: string;
+  amount: number;
+  targetRoleId: string;
+  accentColor: number;
+}): JSXNode => (
+  <Container accentColor={input.accentColor}>
+    <TextDisplay>
+      <H1>🚨 Naruszenie polityki firmy</H1>
+      <Br />
+      Pracownik <Bold>{userMention(input.userId)}</Bold> został przyłapany na{" "}
+      <Bold>dokarmianiu cudzej świni</Bold>. Przekazał <Bold>{input.amount} Paszy</Bold>{" "}
+      do koryta drużyny {roleMention(input.targetRoleId)}.
+      <Br />
+      <Separator divider />
+      <Br />
+      Dokarmianie cudzych świni jest niezgodne z polityką firmy. Dział prawny odnotował
+      incydent i prosi o nieużywanie wyrażenia „katastrofa biologiczna" do czasu
+      zakończenia postępowania.
+    </TextDisplay>
+  </Container>
+);

--- a/apps/bot/src/events/birthday2026/playerView.tsx
+++ b/apps/bot/src/events/birthday2026/playerView.tsx
@@ -232,16 +232,13 @@ export const buildBirthday2026FeedResultView = (
       }
     >
       <TextDisplay>
-        <H1>{isCrossFeed ? "😳 Oops, pomyłka!" : "🥣 Tucznik nakarmiony!"}</H1>
+        <H1>{isCrossFeed ? "Pomyłka!" : "Tucznik nakarmiony!"}</H1>
         <Br />
         {isCrossFeed && targetTeam ? (
           <>
-            Zamiast swojego Tucznika,{" "}
             <Bold>{formatPasza(amount, snapshot.currencySymbol)}</Bold> trafiło do
-            koryta drużyny {roleMention(targetTeam.roleId)}!
-            <Br />
-            Takie przypadki zdarzają się tylko raz na cały event — nikt się nie dowie.
-            👀
+            koryta drużyny {roleMention(targetTeam.roleId)} zamiast Twojego Tucznika.
+            Taka wpadka zdarza się tylko raz, zostaje między nami.
           </>
         ) : (
           <>

--- a/apps/bot/src/events/birthday2026/playerView.tsx
+++ b/apps/bot/src/events/birthday2026/playerView.tsx
@@ -276,17 +276,12 @@ export const buildBirthday2026CrossFeedAnnouncementView = (input: {
 }): JSXNode => (
   <Container accentColor={input.accentColor}>
     <TextDisplay>
-      <H1>🚨 Naruszenie polityki firmy</H1>
+      {userMention(input.userId)} dokarmił cudzego tucznika. Przekazał{" "}
+      <Bold>{input.amount} paszy</Bold> do koryta drużyny{" "}
+      {roleMention(input.targetRoleId)}.
       <Br />
-      Pracownik <Bold>{userMention(input.userId)}</Bold> został przyłapany na{" "}
-      <Bold>dokarmianiu cudzej świni</Bold>. Przekazał <Bold>{input.amount} Paszy</Bold>{" "}
-      do koryta drużyny {roleMention(input.targetRoleId)}.
-      <Br />
-      <Separator divider />
-      <Br />
-      Dokarmianie cudzych świni jest niezgodne z polityką firmy. Dział prawny odnotował
-      incydent i prosi o nieużywanie wyrażenia „katastrofa biologiczna" do czasu
-      zakończenia postępowania.
+      Gildia przypomina, że takie zachowanie jest niezgodne z wewnętrznymi ustaleniami
+      dla poszukiwaczy przygód.
     </TextDisplay>
   </Container>
 );

--- a/apps/bot/src/events/birthday2026/playerView.tsx
+++ b/apps/bot/src/events/birthday2026/playerView.tsx
@@ -238,7 +238,7 @@ export const buildBirthday2026FeedResultView = (
           <>
             <Bold>{formatPasza(amount, snapshot.currencySymbol)}</Bold> trafiło do
             koryta drużyny {roleMention(targetTeam.roleId)} zamiast Twojego Tucznika.
-            Taka wpadka zdarza się tylko raz, zostaje między nami.
+            Taka wpadka zdarza się tylko raz, zostaje między nami... chyba.
           </>
         ) : (
           <>

--- a/apps/bot/src/events/birthday2026/playerView.tsx
+++ b/apps/bot/src/events/birthday2026/playerView.tsx
@@ -26,6 +26,9 @@ import type {
 } from "./playerService";
 
 export const BIRTHDAY_2026_FEED_ALL_CUSTOM_ID = "birthday2026-feed-all";
+export const BIRTHDAY_2026_FEED_TEAM_BUTTON_CUSTOM_ID_PREFIX = "birthday2026-feed-team";
+export const BIRTHDAY_2026_FEED_MODAL_CUSTOM_ID_PREFIX = "birthday2026-feed-modal";
+export const BIRTHDAY_2026_FEED_AMOUNT_CUSTOM_ID = "birthday2026-feed-amount";
 
 const eventStateLabels = {
   disabled: "wstrzymany",

--- a/apps/bot/src/events/birthday2026/statusService.tsx
+++ b/apps/bot/src/events/birthday2026/statusService.tsx
@@ -5,8 +5,10 @@ import {
   type PrismaTransaction,
 } from "@hashira/db";
 import {
+  ActionRow,
   Bold,
   Br,
+  Button,
   Container,
   H1,
   H2,
@@ -16,8 +18,15 @@ import {
   Separator,
   TextDisplay,
 } from "@hashira/jsx";
-import { type Client, RESTJSONErrorCodes, roleMention, userMention } from "discord.js";
+import {
+  ButtonStyle,
+  type Client,
+  RESTJSONErrorCodes,
+  roleMention,
+  userMention,
+} from "discord.js";
 import { discordTry } from "../../util/discordTry";
+import { BIRTHDAY_2026_FEED_TEAM_BUTTON_CUSTOM_ID_PREFIX } from "./playerView";
 
 const milestoneNames = [
   "Początek",
@@ -261,6 +270,13 @@ export const buildBirthday2026TeamStatusView = (
           <MediaGalleryItem url={artwork.imageUrl} />
         </MediaGallery>
       ) : null}
+      <ActionRow>
+        <Button
+          customId={`${BIRTHDAY_2026_FEED_TEAM_BUTTON_CUSTOM_ID_PREFIX}:${team.id}`}
+          label="🥣 Nakarm Tucznika"
+          style={ButtonStyle.Success}
+        />
+      </ActionRow>
     </Container>
   );
 };

--- a/apps/bot/test/birthday2026/economyService.database.test.ts
+++ b/apps/bot/test/birthday2026/economyService.database.test.ts
@@ -203,6 +203,7 @@ databaseTests("Birthday 2026 economy services", () => {
       acceptedAt,
       reason: "Slice 2 integration feed",
       scheduleDigestion,
+      targetTeamConfigId: fixture.team.id,
     };
     const feed = await feedBirthday2026Pig(prisma, feedInput);
     const repeatedFeed = await feedBirthday2026Pig(prisma, feedInput);
@@ -316,6 +317,7 @@ databaseTests("Birthday 2026 economy services", () => {
           acceptedAt: new Date("2026-08-01T18:00:00Z"),
           reason: `Concurrency feed ${key}`,
           scheduleDigestion,
+          targetTeamConfigId: fixture.team.id,
         }),
       ),
     );
@@ -357,5 +359,144 @@ databaseTests("Birthday 2026 economy services", () => {
         },
       }),
     ).toBe(1);
+  });
+
+  it("allows a single cross-team feed per member and credits the target team", async () => {
+    if (!prisma) throw new Error("DATABASE_TEST_URL is required");
+    const suffix = crypto.randomUUID();
+    const guildId = `birthday-cross-guild-${suffix}`;
+    const actorUserId = `birthday-cross-actor-${suffix}`;
+    const memberUserId = `birthday-cross-member-${suffix}`;
+    const otherMemberUserId = `birthday-cross-other-${suffix}`;
+    guildIds.push(guildId);
+    userIds.push(actorUserId, memberUserId, otherMemberUserId);
+
+    await prisma.guild.create({ data: { id: guildId } });
+    await prisma.user.createMany({
+      data: [{ id: actorUserId }, { id: memberUserId }, { id: otherMemberUserId }],
+    });
+
+    const configResult = await upsertBirthday2026Config(prisma, {
+      guildId,
+      eventStartAt: new Date("2026-08-01T18:00:00Z"),
+      eventEndAt: new Date("2026-08-08T18:00:00Z"),
+      timezone: "Europe/Warsaw",
+      visible: true,
+      enabled: true,
+    });
+    if (!configResult.ok) throw new Error(configResult.reason);
+
+    const ownTeamResult = await createBirthday2026Team(prisma, {
+      guildId,
+      name: `Own ${suffix}`,
+      roleId: `own-role-${suffix}`,
+      color: 0xff8800,
+    });
+    const otherTeamResult = await createBirthday2026Team(prisma, {
+      guildId,
+      name: `Other ${suffix}`,
+      roleId: `other-role-${suffix}`,
+      color: 0x00ff88,
+    });
+    if (!ownTeamResult.ok) throw new Error(ownTeamResult.reason);
+    if (!otherTeamResult.ok) throw new Error(otherTeamResult.reason);
+
+    await assignBirthday2026Member(prisma, {
+      guildId,
+      teamConfigId: ownTeamResult.team.id,
+      userId: memberUserId,
+    });
+    await assignBirthday2026Member(prisma, {
+      guildId,
+      teamConfigId: ownTeamResult.team.id,
+      userId: otherMemberUserId,
+    });
+
+    const setup = await setupBirthday2026Economy(prisma, {
+      guildId,
+      currencyName: `Pasza ${suffix}`,
+      currencySymbol: `C${suffix.slice(0, 6)}`,
+      digestionDelaySeconds: 60,
+      createdByUserId: actorUserId,
+    });
+    if (!setup.ok) throw new Error(setup.reason);
+    currencyIds.push(setup.currencyId);
+
+    await grantBirthday2026Pasza(prisma, {
+      guildId,
+      userId: memberUserId,
+      amount: 100,
+      sourceKey: `cross-grant-${suffix}`,
+      createdByUserId: actorUserId,
+      reason: "Cross feed grant",
+    });
+
+    const crossInput = {
+      guildId,
+      userId: memberUserId,
+      amount: 60,
+      sourceKey: `cross-feed-${suffix}`,
+      acceptedAt: new Date("2026-08-01T18:00:00Z"),
+      reason: "Cross team feed",
+      scheduleDigestion,
+      targetTeamConfigId: otherTeamResult.team.id,
+    };
+
+    const cross = await feedBirthday2026Pig(prisma, crossInput);
+    expect(cross).toMatchObject({
+      ok: true,
+      created: true,
+      teamConfigId: otherTeamResult.team.id,
+    });
+    if (!cross.ok) throw new Error(cross.reason);
+
+    const crossAgain = await feedBirthday2026Pig(prisma, {
+      ...crossInput,
+      sourceKey: `cross-feed-again-${suffix}`,
+    });
+    expect(crossAgain).toMatchObject({
+      ok: false,
+      reason: "cross_feed_already_used",
+    });
+
+    const ownFeed = await feedBirthday2026Pig(prisma, {
+      guildId,
+      userId: memberUserId,
+      amount: 30,
+      sourceKey: `own-feed-${suffix}`,
+      acceptedAt: new Date("2026-08-01T18:00:00Z"),
+      reason: "Own team feed",
+      scheduleDigestion,
+      targetTeamConfigId: ownTeamResult.team.id,
+    });
+    expect(ownFeed).toMatchObject({
+      ok: true,
+      created: true,
+      teamConfigId: ownTeamResult.team.id,
+    });
+
+    const personalWallet = await prisma.wallet.findFirstOrThrow({
+      where: { userId: memberUserId, currencyId: setup.currencyId },
+    });
+    const ownWallet = await prisma.birthday2026TeamWallet.findUniqueOrThrow({
+      where: { teamConfigId: ownTeamResult.team.id },
+    });
+    const otherWallet = await prisma.birthday2026TeamWallet.findUniqueOrThrow({
+      where: { teamConfigId: otherTeamResult.team.id },
+    });
+    expect(personalWallet.balance + ownWallet.balance + otherWallet.balance).toBe(100);
+    expect([ownWallet.balance, otherWallet.balance]).toEqual([30, 60]);
+
+    const badCross = await feedBirthday2026Pig(prisma, {
+      guildId,
+      userId: otherMemberUserId,
+      amount: 10,
+      sourceKey: `cross-bad-${suffix}`,
+      acceptedAt: new Date("2026-08-01T18:00:00Z"),
+      reason: "Bad cross target",
+      scheduleDigestion,
+      targetTeamConfigId: 999_999_999,
+    });
+    expect(badCross).toMatchObject({ ok: false, reason: "target_team_not_found" });
   });
 });

--- a/apps/bot/test/birthday2026/finalizationService.database.test.ts
+++ b/apps/bot/test/birthday2026/finalizationService.database.test.ts
@@ -160,10 +160,10 @@ databaseTests("Birthday 2026 final settlement", () => {
       if (!grant.ok) throw new Error(grant.reason);
     }
     const acceptedAt = new Date("2026-08-02T18:00:00Z");
-    for (const [userId, amount] of [
-      [firstMember, 20],
-      [secondMember, 10],
-      [thirdMember, 10],
+    for (const [userId, team, amount] of [
+      [firstMember, first.team, 20],
+      [secondMember, second.team, 10],
+      [thirdMember, second.team, 10],
     ] as const) {
       const feed = await feedBirthday2026Pig(prisma, {
         guildId,
@@ -172,6 +172,7 @@ databaseTests("Birthday 2026 final settlement", () => {
         sourceKey: `settlement-feed:${userId}`,
         acceptedAt,
         reason: "Settlement fixture",
+        targetTeamConfigId: team.id,
         scheduleDigestion,
       });
       if (!feed.ok) throw new Error(feed.reason);

--- a/apps/bot/test/birthday2026/playerService.database.test.ts
+++ b/apps/bot/test/birthday2026/playerService.database.test.ts
@@ -218,6 +218,7 @@ databaseTests("Birthday 2026 public player loop", () => {
       sourceKey: `player-feed-${crypto.randomUUID()}`,
       acceptedAt: new Date("2026-08-03T18:00:00Z"),
       reason: "Player command feed",
+      targetTeamConfigId: fixture.team.id,
       scheduleDigestion,
     });
     expect(feed.ok).toBeTrue();
@@ -251,6 +252,7 @@ databaseTests("Birthday 2026 public player loop", () => {
       sourceKey: `gated-feed-${crypto.randomUUID()}`,
       acceptedAt: new Date("2026-08-03T17:59:59Z"),
       reason: "Gated player feed",
+      targetTeamConfigId: fixture.team.id,
       scheduleDigestion,
     };
 

--- a/apps/bot/test/birthday2026/playerView.test.tsx
+++ b/apps/bot/test/birthday2026/playerView.test.tsx
@@ -5,6 +5,7 @@ import type { Birthday2026PlayerSnapshot } from "../../src/events/birthday2026/p
 import {
   BIRTHDAY_2026_FEED_ALL_CUSTOM_ID,
   buildBirthday2026BalanceView,
+  buildBirthday2026CrossFeedAnnouncementView,
   buildBirthday2026FeedResultView,
   buildBirthday2026InfoView,
   buildBirthday2026RankingView,
@@ -158,5 +159,21 @@ describe("Birthday 2026 player JSX views", () => {
     expect(cross).toContain("<@&role-2>");
     expect(cross).toContain("Pozostałe saldo");
     expect(cross).toContain(BIRTHDAY_2026_FEED_ALL_CUSTOM_ID);
+  });
+
+  it("renders a company-policy announcement for a cross-feed", () => {
+    const announcement = renderJson(
+      buildBirthday2026CrossFeedAnnouncementView({
+        userId: "user-123",
+        amount: 5,
+        targetRoleId: "role-2",
+        accentColor: 0xff0000,
+      }),
+    );
+    expect(announcement).toContain("Naruszenie polityki firmy");
+    expect(announcement).toContain("<@user-123>");
+    expect(announcement).toContain("5 Paszy");
+    expect(announcement).toContain("<@&role-2>");
+    expect(announcement).toContain("katastrofa biologiczna");
   });
 });

--- a/apps/bot/test/birthday2026/playerView.test.tsx
+++ b/apps/bot/test/birthday2026/playerView.test.tsx
@@ -170,10 +170,9 @@ describe("Birthday 2026 player JSX views", () => {
         accentColor: 0xff0000,
       }),
     );
-    expect(announcement).toContain("Naruszenie polityki firmy");
     expect(announcement).toContain("<@user-123>");
-    expect(announcement).toContain("5 Paszy");
+    expect(announcement).toContain("5 paszy");
     expect(announcement).toContain("<@&role-2>");
-    expect(announcement).toContain("katastrofa biologiczna");
+    expect(announcement).toContain("niezgodne z wewnętrznymi ustaleniami");
   });
 });

--- a/apps/bot/test/birthday2026/playerView.test.tsx
+++ b/apps/bot/test/birthday2026/playerView.test.tsx
@@ -137,10 +137,26 @@ describe("Birthday 2026 player JSX views", () => {
         { ...snapshot, balance: 7 },
         5,
         new Date("2026-08-03T22:05:00Z"),
+        snapshot.membership?.teamConfigId ?? 0,
       ),
     );
     expect(result).toContain("Tucznik nakarmiony");
     expect(result).toContain("Pozostałe saldo");
     expect(result).toContain(BIRTHDAY_2026_FEED_ALL_CUSTOM_ID);
+  });
+
+  it("shows a playful message when feeding another team", () => {
+    const cross = renderJson(
+      buildBirthday2026FeedResultView(
+        { ...snapshot, balance: 7 },
+        5,
+        new Date("2026-08-03T22:05:00Z"),
+        2,
+      ),
+    );
+    expect(cross).toContain("Oops, pomyłka!");
+    expect(cross).toContain("<@&role-2>");
+    expect(cross).toContain("Pozostałe saldo");
+    expect(cross).toContain(BIRTHDAY_2026_FEED_ALL_CUSTOM_ID);
   });
 });

--- a/apps/bot/test/birthday2026/playerView.test.tsx
+++ b/apps/bot/test/birthday2026/playerView.test.tsx
@@ -155,7 +155,7 @@ describe("Birthday 2026 player JSX views", () => {
         2,
       ),
     );
-    expect(cross).toContain("Oops, pomyłka!");
+    expect(cross).toContain("Pomyłka!");
     expect(cross).toContain("<@&role-2>");
     expect(cross).toContain("Pozostałe saldo");
     expect(cross).toContain(BIRTHDAY_2026_FEED_ALL_CUSTOM_ID);


### PR DESCRIPTION
## Summary

Feeding a team Tucznik now goes through a shared modal that shows the feeder's current Pasza balance and lets them type the amount.

- **`/tucznik nakarm`** no longer asks for `ilosc` — it opens the feed modal (targeting the caller's own team).
- The per-team status message (`statusService`) gained a **🥣 Nakarm Tucznika** button that opens the **same modal**, targeting that team.
- A user can "accidentally" cross-feed another team at most **once per event**; own-team feeds are unlimited.

## Behavior

1. Feeder opens the modal (command or status button).
2. Modal shows the current Pasza balance and the amount input.
3. On submit, the feed is applied to the selected team's wallet; cross-team feeds are gated by the once-per-event cap.
4. The status message refreshes for the fed team (target `teamConfigId`).

No schema migration required — the once-per-event cross-feed is determined by existing `Birthday2026FeedBatch` rows (a user has cross-fed if they have any batch whose wallet belongs to a team other than their own).

## Refactors

- `FeedBirthday2026PigInput.targetTeamConfigId` is now **required** and always provided by callers.
- Target/once-cap resolution extracted into an immutable `resolveBirthday2026FeedTarget` helper (no `let`/ternary branches).
- Reverted earlier per-team buttons from `/tucznik status` — the button lives on the status *service* message.

## Tests

- Added DB test: one-time cross-team feed per member + target-crediting + `target_team_not_found`.
- Updated existing feed call sites to supply `targetTeamConfigId`.
- Ran `bun run typecheck`, `bun run fix`, and the full `apps/bot/test` suite: **306 pass, 0 fail** (birthday2026: 46 pass).