### PR TITLE
refactor: neutralize gendered user-facing messages

### DIFF
--- a/apps/bot/src/events/birthday2026/index.ts
+++ b/apps/bot/src/events/birthday2026/index.ts
@@ -149,10 +149,10 @@ const playerFeedErrorMessages = {
 } satisfies Record<Birthday2026PlayerFeedErrorReason, string>;
 
 const registrationErrorMessages = {
-  already_assigned: "Jesteś już przypisany do drużyny eventowej.",
-  already_registered: "Jesteś już zapisany do eventu.",
+  already_assigned: "Twój udział jest już przypisany do drużyny eventowej.",
+  already_registered: "Twój udział w evencie jest już zarejestrowany.",
   event_not_available: "Event nie jest teraz dostępny.",
-  not_registered: "Nie jesteś zapisany do eventu.",
+  not_registered: "Twój udział w evencie nie jest zarejestrowany.",
   registration_closed: "Event już się zakończył.",
   teams_not_ready:
     "Wszystkie drużyny muszą najpierw mieć swoich Tuczników i zatwierdzone persony.",
@@ -1679,7 +1679,7 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
           event_settled: "Event został już rozliczony.",
           member_not_found: "Nie należysz do drużyny eventowej.",
           team_wallet_not_found: "Drużyna nie ma portfela eventowego.",
-          win_cap_reached: "Osiągnąłeś limit zwycięstw.",
+          win_cap_reached: "Limit zwycięstw został osiągnięty.",
         };
         await errorFollowUp(itx, messages[result.reason]);
         return;

--- a/apps/bot/src/events/birthday2026/playerView.tsx
+++ b/apps/bot/src/events/birthday2026/playerView.tsx
@@ -99,7 +99,7 @@ export const buildBirthday2026InfoView = (
             {userMention(team.tucznikUserId)}
           </>
         ) : snapshot.registered ? (
-          "Jesteś zapisany. Drużynę otrzymasz przy początkowym przydziale."
+          "Udział jest już zarejestrowany. Drużynę przydzielimy przy początkowym przydziale."
         ) : (
           "Nie należysz jeszcze do drużyny eventowej."
         )}

--- a/apps/bot/src/jajo.ts
+++ b/apps/bot/src/jajo.ts
@@ -69,14 +69,14 @@ const EGG_TABLE = [
 ] as const satisfies ItemTableEntry[];
 
 const WEDKA_MOCK_MESSAGES = [
-  "Zapomniałeś, że łowisko jest zamknięte na wielkanoc?",
+  "Łowisko zamknięte na wielkanoc — czy o tym nie pamiętasz?",
   "Łowisko nieczynne — wielkanocna przerwa!",
   "Ryby mają wolne na święta!",
   "PZW ogłosiło wielkanocny zakaz połowu!",
   "Zamiast moczyć kij, poszukaj lepiej jajek!",
   "Ryby malują pisanki, nie mają czasu na branie.",
   "Królik wielkanocny zarekwirował wszystkie wędki!",
-  "Zarzuciłeś spławik, ale wyłowiłeś tylko mokrą rzeżuchę.",
+  "Zarzucony spławik przyniósł tylko mokrą rzeżuchę.",
   "Państwowa Straż Rybacka sprawdza dzisiaj tylko koszyczki ze święconką.",
   "Szczupak poszedł święcić koszyczki, wraca po świętach.",
   "Wędka zaplątała się w koszyczek. Odpuść sobie i idź szukać pisanek!",
@@ -105,7 +105,7 @@ export const jajo = new Hashira({ name: "jajo" })
 
         if (!canFish) {
           await itx.editReply({
-            content: `Już szukałeś jajek! Zając schowa nowe ${time(nextFishing, TimestampStyles.RelativeTime)}`,
+            content: `Jajka już pozbierane! Zając schowa nowe ${time(nextFishing, TimestampStyles.RelativeTime)}`,
           });
           await sleep(secondsToMilliseconds(5));
           await discordTry(
@@ -204,7 +204,7 @@ export const jajo = new Hashira({ name: "jajo" })
 
         if (!canFish) {
           await itx.editReply({
-            content: `Już szukałeś jajek! Zając schowa nowe ${time(nextFishing, TimestampStyles.RelativeTime)}`,
+            content: `Jajka już pozbierane! Zając schowa nowe ${time(nextFishing, TimestampStyles.RelativeTime)}`,
           });
           await sleep(secondsToMilliseconds(5));
           await discordTry(

--- a/apps/bot/src/moderation/verification.ts
+++ b/apps/bot/src/moderation/verification.ts
@@ -250,7 +250,7 @@ const composeSuccessMessage = (
 
   if (verificationType === "plus18") {
     parts.push(
-      "Z uwagi na Twój wiek dałem Ci też rolę `18+` dzięki której uzyskałeś dostęp do kilku dodatkowych kanałów na serwerze, m.in do `#rozmowy-niesforne`.",
+      "Z uwagi na Twój wiek dodałem Ci też rolę `18+`, dzięki której masz teraz dostęp do kilku dodatkowych kanałów na serwerze, m.in do `#rozmowy-niesforne`.",
     );
   }
 

--- a/apps/bot/src/strata/colorRoles.ts
+++ b/apps/bot/src/strata/colorRoles.ts
@@ -252,7 +252,7 @@ export const colorRoles = new Hashira({ name: "color-role" })
               });
 
               if (!colorRole) {
-                return await errorFollowUp(itx, "Nie jesteś właścicielem tej roli");
+                return await errorFollowUp(itx, "Nie posiadasz tej roli");
               }
 
               const newColors: RoleColorsResolvable = { primaryColor };


### PR DESCRIPTION
## Summary

Rewrites user-facing Polish strings that used a fixed masculine gendered form into gender-neutral (impersonal / restructured) phrasing. Applies to the whole bot, focusing on birthday2026.

## Changes

- `birthday2026/playerView.tsx` — "Jesteś zapisany." → "Udział jest już zarejestrowany."
- `birthday2026/index.ts` — registration/win-cap errors neutralized ("Twój udział …", "Limit zwycięstw został osiągnięty.")
- `strata/colorRoles.ts` — "Nie jesteś właścicielem tej roli" → "Nie posiadasz tej roli"
- `jajo.ts` — fishing/egg messages neutralized
- `moderation/verification.ts` — "…uzyskałeś dostęp…" → "…masz teraz dostęp…"

## Tests

- `bun run typecheck` ✅
- `bun run fix` ✅
- `bun test apps/bot/test/birthday2026/` — 45 pass, 0 fail ✅