### PR TITLE
fix(birthday2026): neutralize cross-feed announcement gender

### DIFF
--- a/apps/bot/src/events/birthday2026/playerView.tsx
+++ b/apps/bot/src/events/birthday2026/playerView.tsx
@@ -273,9 +273,9 @@ export const buildBirthday2026CrossFeedAnnouncementView = (input: {
 }): JSXNode => (
   <Container accentColor={input.accentColor}>
     <TextDisplay>
-      {userMention(input.userId)} dokarmił cudzego tucznika. Przekazał{" "}
-      <Bold>{input.amount} paszy</Bold> do koryta drużyny{" "}
-      {roleMention(input.targetRoleId)}.
+      Cudzy tucznik został nakarmiony przez {userMention(input.userId)} — do koryta
+      drużyny {roleMention(input.targetRoleId)} trafiło{" "}
+      <Bold>{input.amount} paszy</Bold>.
       <Br />
       Gildia przypomina, że takie zachowanie jest niezgodne z wewnętrznymi ustaleniami
       dla poszukiwaczy przygód.


### PR DESCRIPTION
# What

The cross-feed company announcement used two gendered 3rd-person verbs (`dokarmił`, `przekazał`), which were wrong for female users.

## Before
> {user} dokarmił cudzego tucznika. Przekazał N paszy do koryta drużyny {role}.

## After (impersonal / restructured)
> Cudzy tucznik został nakarmiony przez {user} — do koryta drużyny {role} trafiło N paszy.

Uses a passive construction so no gendered verb agrees with the user.

## Tests
- `bun test apps/bot/test/birthday2026/playerView.test.tsx` — 6 pass, 0 fail ✅
- `bun run typecheck` ✅ (no-should-change)