### PR TITLE
feat(birthday2026): allow live reconfiguration of earning caps

### DIFF
--- a/apps/bot/src/events/birthday2026/index.ts
+++ b/apps/bot/src/events/birthday2026/index.ts
@@ -964,8 +964,6 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
                   invalid_daily_cap:
                     "Limit dzienny musi być dodatnią liczbą całkowitą.",
                   invalid_window: "Okno aktywności musi być dodatnią liczbą minut.",
-                  text_earning_already_used:
-                    "Nie można zmienić reguł tekstowych po przyznaniu pierwszej Paszy.",
                 };
                 await errorFollowUp(itx, messages[result.reason]);
                 return;
@@ -1007,8 +1005,6 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
                   invalid_daily_cap:
                     "Limit dzienny musi być dodatnią liczbą całkowitą.",
                   invalid_unit: "Jednostka głosowa musi być dodatnią liczbą minut.",
-                  voice_earning_already_used:
-                    "Nie można zmienić reguł głosowych po przyznaniu pierwszej Paszy.",
                 };
                 await errorFollowUp(itx, messages[result.reason]);
                 return;

--- a/apps/bot/src/events/birthday2026/playerView.tsx
+++ b/apps/bot/src/events/birthday2026/playerView.tsx
@@ -273,9 +273,9 @@ export const buildBirthday2026CrossFeedAnnouncementView = (input: {
 }): JSXNode => (
   <Container accentColor={input.accentColor}>
     <TextDisplay>
-      {userMention(input.userId)} dokarmił cudzego tucznika. Przekazał{" "}
-      <Bold>{input.amount} paszy</Bold> do koryta drużyny{" "}
-      {roleMention(input.targetRoleId)}.
+      Cudzy tucznik został nakarmiony przez {userMention(input.userId)} — do koryta
+      drużyny {roleMention(input.targetRoleId)} trafiło{" "}
+      <Bold>{input.amount} paszy</Bold>.
       <Br />
       Gildia przypomina, że takie zachowanie jest niezgodne z wewnętrznymi ustaleniami
       dla poszukiwaczy przygód.

--- a/apps/bot/src/events/birthday2026/textEarningService.ts
+++ b/apps/bot/src/events/birthday2026/textEarningService.ts
@@ -20,18 +20,13 @@ export type Birthday2026TextEarningErrorReason =
   | "invalid_occurred_at"
   | "invalid_window"
   | "member_not_found"
-  | "text_earning_already_used"
   | "text_earning_not_configured";
 
 export type ConfigureBirthday2026TextEarningResult =
   | { ok: true; config: Birthday2026TextEarningConfig }
   | {
       ok: false;
-      reason:
-        | "config_not_found"
-        | "invalid_daily_cap"
-        | "invalid_window"
-        | "text_earning_already_used";
+      reason: "config_not_found" | "invalid_daily_cap" | "invalid_window";
     };
 
 export const configureBirthday2026TextEarning = async (
@@ -60,14 +55,6 @@ export const configureBirthday2026TextEarning = async (
       config.textEarning.dailyCap === input.dailyCap
     ) {
       return { ok: true, config: config.textEarning };
-    }
-
-    const existingAward = await tx.birthday2026PersonalTransaction.findFirst({
-      where: { configId: config.id, source: "textActivity" },
-      select: { id: true },
-    });
-    if (existingAward) {
-      return { ok: false, reason: "text_earning_already_used" };
     }
 
     const textEarning = await tx.birthday2026TextEarningConfig.upsert({

--- a/apps/bot/src/events/birthday2026/voiceEarningService.ts
+++ b/apps/bot/src/events/birthday2026/voiceEarningService.ts
@@ -16,11 +16,7 @@ export type ConfigureBirthday2026VoiceEarningResult =
   | { ok: true; config: Birthday2026VoiceEarningConfig }
   | {
       ok: false;
-      reason:
-        | "config_not_found"
-        | "invalid_daily_cap"
-        | "invalid_unit"
-        | "voice_earning_already_used";
+      reason: "config_not_found" | "invalid_daily_cap" | "invalid_unit";
     };
 
 export const configureBirthday2026VoiceEarning = async (
@@ -49,14 +45,6 @@ export const configureBirthday2026VoiceEarning = async (
       config.voiceEarning.dailyCap === input.dailyCap
     ) {
       return { ok: true, config: config.voiceEarning };
-    }
-
-    const existingAward = await tx.birthday2026PersonalTransaction.findFirst({
-      where: { configId: config.id, source: "voiceActivity" },
-      select: { id: true },
-    });
-    if (existingAward) {
-      return { ok: false, reason: "voice_earning_already_used" };
     }
 
     return {

--- a/apps/bot/test/birthday2026/textEarningService.database.test.ts
+++ b/apps/bot/test/birthday2026/textEarningService.database.test.ts
@@ -261,9 +261,12 @@ databaseTests("Birthday 2026 text earning", () => {
       await configureBirthday2026TextEarning(prisma, {
         guildId: fixture.guildId,
         windowSeconds: 600,
-        dailyCap: 24,
+        dailyCap: 12,
       }),
-    ).toEqual({ ok: false, reason: "text_earning_already_used" });
+    ).toMatchObject({ ok: true, config: { windowSeconds: 600, dailyCap: 12 } });
+    expect(
+      await getBirthday2026TextEarningDiagnostics(prisma, fixture.guildId),
+    ).toMatchObject({ windowSeconds: 600, dailyCap: 12 });
   });
 
   it("enforces the daily cap atomically across concurrent windows", async () => {

--- a/apps/bot/test/birthday2026/voiceEarningService.database.test.ts
+++ b/apps/bot/test/birthday2026/voiceEarningService.database.test.ts
@@ -268,9 +268,12 @@ databaseTests("Birthday 2026 voice earning", () => {
       await configureBirthday2026VoiceEarning(prisma, {
         guildId: fixture.guildId,
         unitSeconds: 300,
-        dailyCap: 18,
+        dailyCap: 9,
       }),
-    ).toEqual({ ok: false, reason: "voice_earning_already_used" });
+    ).toMatchObject({ ok: true, config: { unitSeconds: 300, dailyCap: 9 } });
+    expect(
+      await getBirthday2026VoiceEarningDiagnostics(prisma, fixture.guildId),
+    ).toMatchObject({ unitSeconds: 300, dailyCap: 9 });
   });
 
   it("enforces the daily cap across concurrent completed sessions", async () => {


### PR DESCRIPTION
## Summary

The Birthday 2026 text and voice earning rules previously errored with `text_earning_already_used` / `voice_earning_already_used` once any Pasza had been awarded, so the daily cap and window/unit could not be changed mid-event. This removes that guard, letting moderators adjust the daily cap (and window/unit) live while the event runs.

- `configureBirthday2026TextEarning` / `configureBirthday2026VoiceEarning` now upsert config even after awards exist.
- Dropped the now-dead `*_earning_already_used` error reasons and their Discord UI messages.
- Lowering the cap stops further accrual but never touches already-awarded counters; window/unit changes keep `sourceKey` dedupe intact.

## Tests
- `bun test` full suite: 417 pass, 0 fail (against `DATABASE_TEST_URL`)
- `bun run typecheck`: all workspaces clean