### PR TITLE
feat(birthday2026): add admin statystyki and drop /tucznik zrezygnuj

### DIFF
--- a/apps/bot/src/events/birthday2026/index.ts
+++ b/apps/bot/src/events/birthday2026/index.ts
@@ -3,6 +3,7 @@ import type { ExtendedPrismaClient, PrismaTransaction } from "@hashira/db";
 import { render } from "@hashira/jsx";
 import {
   ActionRowBuilder,
+  AttachmentBuilder,
   type ButtonInteraction,
   bold,
   type ChatInputCommandInteraction,
@@ -83,6 +84,7 @@ import {
   withdrawBirthday2026Registration,
 } from "./registrationService";
 import { parseBirthday2026Instant } from "./staffInput";
+import { getBirthday2026Stats, renderBirthday2026StatsFile } from "./statsService";
 import {
   configureBirthday2026Artwork,
   configureBirthday2026Milestones,
@@ -1440,6 +1442,52 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
                     .join("\n")
                 : "Brak wykluczonych kanałów.",
             );
+          }),
+      )
+      .addCommand("statystyki", (command) =>
+        command
+          .setDescription("Pobierz szczegółowe statystyki Paszy eventu")
+          .handle(async ({ prisma }, _, itx) => {
+            if (!itx.inCachedGuild()) return;
+            await itx.deferReply({ flags: "Ephemeral" });
+
+            const result = await getBirthday2026Stats(prisma, itx.guildId);
+            if (!result.ok) {
+              await errorFollowUp(
+                itx,
+                result.reason === "config_not_found"
+                  ? "Event urodzinowy nie jest skonfigurowany."
+                  : "Najpierw skonfiguruj ekonomię eventu.",
+              );
+              return;
+            }
+
+            const { stats } = result;
+            const teamLines = stats.teams
+              .map(
+                (team, index) =>
+                  `${index + 1}. ${bold(team.teamName)} — ${team.totalPasza.toLocaleString("pl-PL")} Paszy łącznie (waga ${team.permanentWeight.toLocaleString("pl-PL")} + koryto ${team.troughBalance.toLocaleString("pl-PL")}) — ${team.contributorCount} karmiących / ${team.memberCount} osób — ${team.sharePercent.toFixed(1)}%`,
+              )
+              .join("\n");
+
+            const attachment = new AttachmentBuilder(
+              Buffer.from(renderBirthday2026StatsFile(stats, itx.createdAt), "utf-8"),
+              {
+                name: `birthday2026-statystyki-${itx.createdAt.toISOString().slice(0, 10)}.txt`,
+              },
+            );
+
+            await itx.editReply({
+              content: [
+                `${bold("Statystyki Birthday 2026")}`,
+                `Łączna Pasza w drużynach: ${stats.totalTeamPasza.toLocaleString("pl-PL")}, zarobiona: ${stats.totalEarnedPasza.toLocaleString("pl-PL")}, przekazana świniom: ${stats.totalFedPasza.toLocaleString("pl-PL")}, niewydana: ${stats.totalUnspentPasza.toLocaleString("pl-PL")}.`,
+                "",
+                teamLines || "Brak drużyn.",
+                "",
+                "Pełne dane (w tym niewydana Pasza per członek) w załączonym pliku.",
+              ].join("\n"),
+              files: [attachment],
+            });
           }),
       ),
   )

--- a/apps/bot/src/events/birthday2026/index.ts
+++ b/apps/bot/src/events/birthday2026/index.ts
@@ -81,7 +81,6 @@ import {
   finalizeBirthday2026Registration,
   findBirthday2026RoleAssignments,
   registerBirthday2026Participant,
-  withdrawBirthday2026Registration,
 } from "./registrationService";
 import { parseBirthday2026Instant } from "./staffInput";
 import { getBirthday2026Stats, renderBirthday2026StatsFile } from "./statsService";
@@ -449,26 +448,6 @@ export const birthday2026 = new Hashira({ name: "birthday2026" })
                   : " Nie udało się nadać roli; administracja może uruchomić synchronizację."
               }`,
             );
-          }),
-      )
-      .addCommand("zrezygnuj", (command) =>
-        command
-          .setDescription("Wycofaj zapis przed przydzieleniem drużyny")
-          .handle(async ({ prisma }, _, itx) => {
-            if (!itx.inCachedGuild()) return;
-            await itx.deferReply({ flags: "Ephemeral" });
-
-            const result = await withdrawBirthday2026Registration(
-              prisma,
-              itx.guildId,
-              itx.user.id,
-              itx.createdAt,
-            );
-            if (!result.ok) {
-              await errorFollowUp(itx, registrationErrorMessages[result.reason]);
-              return;
-            }
-            await itx.editReply("Wycofano Twój zapis do eventu.");
           }),
       )
       .addCommand("info", (command) =>

--- a/apps/bot/src/events/birthday2026/statsService.ts
+++ b/apps/bot/src/events/birthday2026/statsService.ts
@@ -1,0 +1,398 @@
+import type { PrismaTransaction } from "@hashira/db";
+
+export type Birthday2026TeamStats = {
+  teamConfigId: number;
+  teamName: string;
+  roleId: string;
+  memberCount: number;
+  permanentWeight: number;
+  troughBalance: number;
+  totalPasza: number;
+  contributorCount: number;
+  sharePercent: number;
+};
+
+export type Birthday2026MemberStats = {
+  userId: string;
+  teamConfigId: number;
+  earned: number;
+  earnedText: number;
+  earnedVoice: number;
+  earnedEncounter: number;
+  earnedStaffGrant: number;
+  fed: number;
+  feedCount: number;
+  unspent: number;
+};
+
+export type Birthday2026SourceStats = {
+  teamConfigId: number;
+  teamName: string;
+  memberCount: number;
+  avgPerMember: number;
+  text: number;
+  voice: number;
+  encounter: number;
+  staffGrant: number;
+  textSharePercent: number;
+  voiceSharePercent: number;
+  encounterSharePercent: number;
+  staffGrantSharePercent: number;
+};
+
+export type Birthday2026Stats = {
+  teams: Birthday2026TeamStats[];
+  members: Birthday2026MemberStats[];
+  sources: Birthday2026SourceStats[];
+  totalEarnedPasza: number;
+  totalFedPasza: number;
+  totalTeamPasza: number;
+  totalUnspentPasza: number;
+};
+
+export type GetBirthday2026StatsResult =
+  | { ok: true; stats: Birthday2026Stats }
+  | { ok: false; reason: "config_not_found" | "economy_not_configured" };
+
+const EARNED_SOURCES = [
+  "staffGrant",
+  "textActivity",
+  "voiceActivity",
+  "encounter",
+] as const;
+
+type EarnedBySource = {
+  text: number;
+  voice: number;
+  encounter: number;
+  staffGrant: number;
+};
+
+const emptyEarned = (): EarnedBySource => ({
+  text: 0,
+  voice: 0,
+  encounter: 0,
+  staffGrant: 0,
+});
+
+const earnedTotal = (earned: EarnedBySource) =>
+  earned.text + earned.voice + earned.encounter + earned.staffGrant;
+
+export const getBirthday2026Stats = async (
+  prisma: PrismaTransaction,
+  guildId: string,
+): Promise<GetBirthday2026StatsResult> => {
+  const config = await prisma.birthday2026Config.findUnique({
+    where: { guildId },
+    include: {
+      economy: { select: { currencyId: true } },
+      teams: {
+        include: {
+          team: true,
+          wallet: { select: { id: true, balance: true, permanentWeight: true } },
+          memberStates: { select: { userId: true } },
+        },
+        orderBy: { id: "asc" },
+      },
+    },
+  });
+  if (!config) return { ok: false, reason: "config_not_found" } as const;
+  if (!config.economy) {
+    return { ok: false, reason: "economy_not_configured" } as const;
+  }
+
+  const teams = config.teams;
+  const memberUserIds = [
+    ...new Set(
+      teams.flatMap((team) => team.memberStates.map((member) => member.userId)),
+    ),
+  ];
+
+  const [contributorRows, feedByUser, earnedRows, wallets] = await Promise.all([
+    prisma.birthday2026FeedBatch.findMany({
+      where: { configId: config.id },
+      distinct: ["walletId", "userId"],
+      select: { walletId: true },
+    }),
+    prisma.birthday2026FeedBatch.groupBy({
+      by: ["userId"],
+      where: { configId: config.id },
+      _sum: { amount: true },
+      _count: { userId: true },
+    }),
+    prisma.birthday2026PersonalTransaction.findMany({
+      where: { configId: config.id, source: { in: [...EARNED_SOURCES] } },
+      select: {
+        userId: true,
+        source: true,
+        transaction: { select: { amount: true } },
+      },
+    }),
+    memberUserIds.length > 0
+      ? prisma.wallet.findMany({
+          where: {
+            currencyId: config.economy.currencyId,
+            default: true,
+            guildId,
+            userId: { in: memberUserIds },
+          },
+          select: { userId: true, balance: true },
+        })
+      : Promise.resolve([] as { userId: string; balance: number }[]),
+  ]);
+
+  const contributorCountByWallet = new Map<number, number>();
+  for (const row of contributorRows) {
+    contributorCountByWallet.set(
+      row.walletId,
+      (contributorCountByWallet.get(row.walletId) ?? 0) + 1,
+    );
+  }
+
+  const earnedByUser = new Map<string, EarnedBySource>();
+  for (const row of earnedRows) {
+    const earned = earnedByUser.get(row.userId) ?? emptyEarned();
+    if (row.source === "textActivity") earned.text += row.transaction.amount;
+    else if (row.source === "voiceActivity") earned.voice += row.transaction.amount;
+    else if (row.source === "encounter") earned.encounter += row.transaction.amount;
+    else earned.staffGrant += row.transaction.amount;
+    earnedByUser.set(row.userId, earned);
+  }
+
+  const fedByUser = new Map<string, { fed: number; feedCount: number }>();
+  for (const row of feedByUser) {
+    fedByUser.set(row.userId, {
+      fed: row._sum.amount ?? 0,
+      feedCount: row._count.userId,
+    });
+  }
+
+  const balanceByUser = new Map(
+    wallets.map((wallet) => [wallet.userId, wallet.balance] as const),
+  );
+  const teamByUserId = new Map<string, number>();
+  for (const team of teams) {
+    for (const member of team.memberStates) {
+      teamByUserId.set(member.userId, team.id);
+    }
+  }
+
+  const totalTeamPasza = teams.reduce(
+    (total, team) =>
+      total + (team.wallet ? team.wallet.permanentWeight + team.wallet.balance : 0),
+    0,
+  );
+  const teamStats: Birthday2026TeamStats[] = teams.map((team) => {
+    const totalPasza = team.wallet
+      ? team.wallet.permanentWeight + team.wallet.balance
+      : 0;
+    return {
+      teamConfigId: team.id,
+      teamName: team.team.name,
+      roleId: team.roleId,
+      memberCount: team.memberStates.length,
+      permanentWeight: team.wallet?.permanentWeight ?? 0,
+      troughBalance: team.wallet?.balance ?? 0,
+      totalPasza,
+      contributorCount: team.wallet
+        ? (contributorCountByWallet.get(team.wallet.id) ?? 0)
+        : 0,
+      sharePercent: totalTeamPasza > 0 ? (totalPasza / totalTeamPasza) * 100 : 0,
+    };
+  });
+
+  const memberStats: Birthday2026MemberStats[] = teams.flatMap((team) =>
+    team.memberStates.map((member) => {
+      const earned = earnedByUser.get(member.userId) ?? emptyEarned();
+      const fed = fedByUser.get(member.userId) ?? { fed: 0, feedCount: 0 };
+      return {
+        userId: member.userId,
+        teamConfigId: team.id,
+        earned: earnedTotal(earned),
+        earnedText: earned.text,
+        earnedVoice: earned.voice,
+        earnedEncounter: earned.encounter,
+        earnedStaffGrant: earned.staffGrant,
+        fed: fed.fed,
+        feedCount: fed.feedCount,
+        unspent: balanceByUser.get(member.userId) ?? 0,
+      };
+    }),
+  );
+
+  const sourceStats: Birthday2026SourceStats[] = teams
+    .map((team) => {
+      const sourceTotals = emptyEarned();
+      for (const member of team.memberStates) {
+        const earned = earnedByUser.get(member.userId);
+        if (!earned) continue;
+        sourceTotals.text += earned.text;
+        sourceTotals.voice += earned.voice;
+        sourceTotals.encounter += earned.encounter;
+        sourceTotals.staffGrant += earned.staffGrant;
+      }
+      const teamEarned = earnedTotal(sourceTotals);
+      const percent = (value: number) =>
+        teamEarned > 0 ? (value / teamEarned) * 100 : 0;
+      return {
+        teamConfigId: team.id,
+        teamName: team.team.name,
+        memberCount: team.memberStates.length,
+        avgPerMember:
+          team.memberStates.length > 0 ? teamEarned / team.memberStates.length : 0,
+        text: sourceTotals.text,
+        voice: sourceTotals.voice,
+        encounter: sourceTotals.encounter,
+        staffGrant: sourceTotals.staffGrant,
+        textSharePercent: percent(sourceTotals.text),
+        voiceSharePercent: percent(sourceTotals.voice),
+        encounterSharePercent: percent(sourceTotals.encounter),
+        staffGrantSharePercent: percent(sourceTotals.staffGrant),
+      };
+    })
+    .sort(
+      (a, b) =>
+        b.text +
+        b.voice +
+        b.encounter +
+        b.staffGrant -
+        (a.text + a.voice + a.encounter + a.staffGrant),
+    );
+
+  return {
+    ok: true,
+    stats: {
+      teams: teamStats,
+      members: memberStats,
+      sources: sourceStats,
+      totalEarnedPasza: memberStats.reduce((total, member) => total + member.earned, 0),
+      totalFedPasza: memberStats.reduce((total, member) => total + member.fed, 0),
+      totalTeamPasza,
+      totalUnspentPasza: memberStats.reduce(
+        (total, member) => total + member.unspent,
+        0,
+      ),
+    },
+  };
+};
+
+const tsv = (header: string[], rows: (string | number)[][]): string =>
+  [header, ...rows].map((columns) => columns.join("\t")).join("\n");
+
+const toFixed = (value: number, digits = 1) => value.toFixed(digits);
+
+export const renderBirthday2026StatsFile = (
+  stats: Birthday2026Stats,
+  generatedAt: Date,
+): string => {
+  const sections: string[] = [
+    `Birthday 2026 - statystyki Paszy (${generatedAt.toLocaleString("pl-PL")})`,
+    "",
+  ];
+
+  sections.push(
+    "1) DRUŻYNY - łączna Pasza w drużynie",
+    tsv(
+      [
+        "druzyna",
+        "waga_stala",
+        "koryto",
+        "pasza_lacznie",
+        "udzial_pct",
+        "karmiacy",
+        "czlonkowie",
+      ],
+      stats.teams
+        .toSorted(
+          (a, b) =>
+            b.totalPasza - a.totalPasza || a.teamName.localeCompare(b.teamName, "pl"),
+        )
+        .map((team) => [
+          team.teamName,
+          team.permanentWeight,
+          team.troughBalance,
+          team.totalPasza,
+          toFixed(team.sharePercent),
+          team.contributorCount,
+          team.memberCount,
+        ]),
+    ),
+    "",
+  );
+
+  sections.push(
+    "2) ZAROBKI WG ZRODLA (na drużynę)",
+    tsv(
+      [
+        "druzyna",
+        "czlonkowie",
+        "srednio_na_czlonka",
+        "tekst",
+        "glos",
+        "wydarzenia",
+        "granty_staffu",
+        "tekst_pct",
+        "glos_pct",
+        "wydarzenia_pct",
+        "granty_pct",
+      ],
+      stats.sources.map((source) => [
+        source.teamName,
+        source.memberCount,
+        toFixed(source.avgPerMember),
+        source.text,
+        source.voice,
+        source.encounter,
+        source.staffGrant,
+        toFixed(source.textSharePercent),
+        toFixed(source.voiceSharePercent),
+        toFixed(source.encounterSharePercent),
+        toFixed(source.staffGrantSharePercent),
+      ]),
+    ),
+    "",
+  );
+
+  sections.push(
+    "3) CZŁONKOWIE - niewydana Pasza na osobę",
+    tsv(
+      [
+        "user_id",
+        "druzyna",
+        "zarobiona",
+        "tekst",
+        "glos",
+        "wydarzenia",
+        "granty_staffu",
+        "przekazana",
+        "liczba_feedow",
+        "niewydana",
+      ],
+      stats.members
+        .toSorted(
+          (a, b) =>
+            teamNameOf(stats, a.teamConfigId).localeCompare(
+              teamNameOf(stats, b.teamConfigId),
+              "pl",
+            ) || a.userId.localeCompare(b.userId),
+        )
+        .map((member) => [
+          member.userId,
+          teamNameOf(stats, member.teamConfigId),
+          member.earned,
+          member.earnedText,
+          member.earnedVoice,
+          member.earnedEncounter,
+          member.earnedStaffGrant,
+          member.fed,
+          member.feedCount,
+          member.unspent,
+        ]),
+    ),
+  );
+
+  return `${sections.join("\n")}\n`;
+};
+
+const teamNameOf = (stats: Birthday2026Stats, teamConfigId: number) =>
+  stats.teams.find((team) => team.teamConfigId === teamConfigId)?.teamName ?? "";

--- a/apps/bot/test/birthday2026/statsService.database.test.ts
+++ b/apps/bot/test/birthday2026/statsService.database.test.ts
@@ -1,0 +1,296 @@
+import { afterAll, describe, expect, it } from "bun:test";
+import { PrismaClient, type PrismaTransaction } from "@hashira/db";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { upsertBirthday2026Config } from "../../src/events/birthday2026/configService";
+import {
+  feedBirthday2026Pig,
+  grantBirthday2026Pasza,
+  setupBirthday2026Economy,
+} from "../../src/events/birthday2026/economyService";
+import { getBirthday2026Stats } from "../../src/events/birthday2026/statsService";
+import {
+  assignBirthday2026Member,
+  createBirthday2026Team,
+} from "../../src/events/birthday2026/teamService";
+
+const connectionString = process.env.DATABASE_TEST_URL;
+const databaseTests = describe.skipIf(!connectionString);
+const prisma = connectionString
+  ? new PrismaClient({
+      adapter: new PrismaPg({ connectionString }),
+    })
+  : null;
+
+const guildIds: string[] = [];
+const userIds: string[] = [];
+const currencyIds: number[] = [];
+
+databaseTests("Birthday 2026 staff stats", () => {
+  afterAll(async () => {
+    if (!prisma) return;
+
+    await prisma.birthday2026TeamWalletTransaction.deleteMany({
+      where: {
+        wallet: {
+          teamConfig: {
+            config: { guildId: { in: guildIds } },
+          },
+        },
+      },
+    });
+    await prisma.birthday2026Config.deleteMany({
+      where: { guildId: { in: guildIds } },
+    });
+    await prisma.transaction.deleteMany({
+      where: { wallet: { currencyId: { in: currencyIds } } },
+    });
+    await prisma.wallet.deleteMany({
+      where: { currencyId: { in: currencyIds } },
+    });
+    await prisma.currency.deleteMany({ where: { id: { in: currencyIds } } });
+    await prisma.team.deleteMany({ where: { guildId: { in: guildIds } } });
+    await prisma.guild.deleteMany({ where: { id: { in: guildIds } } });
+    await prisma.user.deleteMany({ where: { id: { in: userIds } } });
+    await prisma.$disconnect();
+  });
+
+  it("reports per-team and per-member pasza aggregates", async () => {
+    if (!prisma) throw new Error("DATABASE_TEST_URL is required");
+    const suffix = crypto.randomUUID();
+    const guildId = `birthday-stats-guild-${suffix}`;
+    const actorUserId = `birthday-stats-actor-${suffix}`;
+    const memberAlphaId = `birthday-stats-alpha-${suffix}`;
+    const memberBetaId = `birthday-stats-beta-${suffix}`;
+    guildIds.push(guildId);
+    userIds.push(actorUserId, memberAlphaId, memberBetaId);
+
+    await prisma.guild.create({ data: { id: guildId } });
+    await prisma.user.createMany({
+      data: [{ id: actorUserId }, { id: memberAlphaId }, { id: memberBetaId }],
+    });
+
+    const configResult = await upsertBirthday2026Config(prisma, {
+      guildId,
+      eventStartAt: new Date("2026-08-01T18:00:00Z"),
+      eventEndAt: new Date("2026-08-08T18:00:00Z"),
+      timezone: "Europe/Warsaw",
+      visible: true,
+      enabled: true,
+    });
+    if (!configResult.ok) throw new Error(configResult.reason);
+
+    const alphaTeamResult = await createBirthday2026Team(prisma, {
+      guildId,
+      name: `Alpha ${suffix}`,
+      roleId: `alpha-role-${suffix}`,
+      color: 0xff8800,
+    });
+    const betaTeamResult = await createBirthday2026Team(prisma, {
+      guildId,
+      name: `Beta ${suffix}`,
+      roleId: `beta-role-${suffix}`,
+      color: 0x0088ff,
+    });
+    if (!alphaTeamResult.ok) throw new Error(alphaTeamResult.reason);
+    if (!betaTeamResult.ok) throw new Error(betaTeamResult.reason);
+
+    await assignBirthday2026Member(prisma, {
+      guildId,
+      teamConfigId: alphaTeamResult.team.id,
+      userId: memberAlphaId,
+    });
+    await assignBirthday2026Member(prisma, {
+      guildId,
+      teamConfigId: betaTeamResult.team.id,
+      userId: memberBetaId,
+    });
+
+    const setup = await setupBirthday2026Economy(prisma, {
+      guildId,
+      currencyName: `Pasza ${suffix}`,
+      currencySymbol: `S${suffix.slice(0, 6)}`,
+      digestionDelaySeconds: 3600,
+      createdByUserId: actorUserId,
+    });
+    if (!setup.ok) throw new Error(setup.reason);
+    currencyIds.push(setup.currencyId);
+
+    const configId = configResult.config.id;
+    const currencyId = setup.currencyId;
+
+    await grantBirthday2026Pasza(prisma, {
+      guildId,
+      userId: memberAlphaId,
+      amount: 50,
+      sourceKey: `stats-grant-alpha-${suffix}`,
+      createdByUserId: actorUserId,
+      reason: "Grant",
+    });
+    await grantBirthday2026Pasza(prisma, {
+      guildId,
+      userId: memberBetaId,
+      amount: 20,
+      sourceKey: `stats-grant-beta-${suffix}`,
+      createdByUserId: actorUserId,
+      reason: "Grant",
+    });
+
+    const earn = async (
+      userId: string,
+      amount: number,
+      source: "encounter" | "textActivity" | "voiceActivity",
+    ) => {
+      if (!prisma) throw new Error("DATABASE_TEST_URL is required");
+      const wallet = await prisma.wallet.findFirstOrThrow({
+        where: { userId, currencyId, default: true },
+      });
+      await prisma.wallet.update({
+        where: { id: wallet.id },
+        data: { balance: { increment: amount } },
+      });
+      const transaction = await prisma.transaction.create({
+        data: {
+          walletId: wallet.id,
+          amount,
+          reason: source,
+          transactionType: "add",
+          entryType: "credit",
+        },
+      });
+      await prisma.birthday2026PersonalTransaction.create({
+        data: {
+          configId,
+          userId,
+          transactionId: transaction.id,
+          source,
+          sourceKey: `stats-${source}-${userId}-${suffix}`,
+        },
+      });
+    };
+
+    await earn(memberAlphaId, 30, "textActivity");
+    await earn(memberAlphaId, 10, "voiceActivity");
+    await earn(memberBetaId, 40, "textActivity");
+
+    const scheduleDigestion = async (
+      tx: PrismaTransaction,
+      batch: { id: number; digestAt: Date },
+    ) => {
+      await tx.task.create({
+        data: {
+          identifier: batch.id.toString(),
+          handleAfter: batch.digestAt,
+          data: { type: "birthday2026Digest", data: { batchId: batch.id } },
+        },
+      });
+    };
+
+    const acceptedAt = new Date("2026-08-01T18:00:00Z");
+    await feedBirthday2026Pig(prisma, {
+      guildId,
+      userId: memberAlphaId,
+      amount: 40,
+      sourceKey: `stats-feed-alpha-${suffix}`,
+      acceptedAt,
+      reason: "Feed",
+      scheduleDigestion,
+      targetTeamConfigId: alphaTeamResult.team.id,
+    });
+    await feedBirthday2026Pig(prisma, {
+      guildId,
+      userId: memberBetaId,
+      amount: 10,
+      sourceKey: `stats-feed-beta-${suffix}`,
+      acceptedAt,
+      reason: "Feed",
+      scheduleDigestion,
+      targetTeamConfigId: betaTeamResult.team.id,
+    });
+
+    const result = await getBirthday2026Stats(prisma, guildId);
+    if (!result.ok) throw new Error(result.reason);
+    const { stats } = result;
+
+    const alpha = stats.teams.find(
+      (team) => team.teamConfigId === alphaTeamResult.team.id,
+    );
+    const beta = stats.teams.find(
+      (team) => team.teamConfigId === betaTeamResult.team.id,
+    );
+    expect(alpha).toMatchObject({
+      memberCount: 1,
+      permanentWeight: 0,
+      troughBalance: 40,
+      totalPasza: 40,
+      contributorCount: 1,
+    });
+    expect(beta).toMatchObject({
+      memberCount: 1,
+      permanentWeight: 0,
+      troughBalance: 10,
+      totalPasza: 10,
+      contributorCount: 1,
+    });
+    expect(alpha?.sharePercent ?? 0).toBeGreaterThan(beta?.sharePercent ?? 0);
+
+    const alphaMember = stats.members.find((member) => member.userId === memberAlphaId);
+    const betaMember = stats.members.find((member) => member.userId === memberBetaId);
+    expect(alphaMember).toMatchObject({
+      earned: 90,
+      earnedText: 30,
+      earnedVoice: 10,
+      earnedEncounter: 0,
+      earnedStaffGrant: 50,
+      fed: 40,
+      feedCount: 1,
+      unspent: 50,
+    });
+    expect(betaMember).toMatchObject({
+      earned: 60,
+      earnedText: 40,
+      earnedVoice: 0,
+      earnedStaffGrant: 20,
+      fed: 10,
+      feedCount: 1,
+      unspent: 50,
+    });
+    expect(stats.totalEarnedPasza).toBe(150);
+    expect(stats.totalFedPasza).toBe(50);
+    expect(stats.totalUnspentPasza).toBe(100);
+    expect(stats.totalTeamPasza).toBe(50);
+
+    const alphaSource = stats.sources.find(
+      (source) => source.teamConfigId === alphaTeamResult.team.id,
+    );
+    expect(alphaSource).toMatchObject({
+      text: 30,
+      voice: 10,
+      encounter: 0,
+      staffGrant: 50,
+    });
+    expect(alphaSource?.textSharePercent ?? 0).toBe((30 / 90) * 100);
+  });
+
+  it("reports empty stats before the economy is configured", async () => {
+    if (!prisma) throw new Error("DATABASE_TEST_URL is required");
+    const suffix = crypto.randomUUID();
+    const guildId = `birthday-stats-empty-${suffix}`;
+    guildIds.push(guildId);
+
+    await prisma.guild.create({ data: { id: guildId } });
+    const configResult = await upsertBirthday2026Config(prisma, {
+      guildId,
+      eventStartAt: new Date("2026-08-01T18:00:00Z"),
+      eventEndAt: new Date("2026-08-08T18:00:00Z"),
+      timezone: "Europe/Warsaw",
+      visible: true,
+      enabled: true,
+    });
+    if (!configResult.ok) throw new Error(configResult.reason);
+
+    expect(await getBirthday2026Stats(prisma, guildId)).toEqual({
+      ok: false,
+      reason: "economy_not_configured",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Two changes in the Birthday 2026 event:

1. **`/urodziny-admin statystyki`** — new admin command that replies with a per-team Pasza summary plus a tab-delimited `.txt` attachment (paste-friendly for Excel/Sheets) with three tables:
   - **Teams**: permanent weight (`waga_stala`), trough balance (`koryto`), total Pasza in the team (`waga + koryto`), share of total, feeder count, member count.
   - **Earning sources per team**: text / voice / encounters / staff grants + average per member, to diagnose big discrepancies between teams.
   - **Members**: per-member earned (split by source), fed, feed count, and **unspent Pasza** (current wallet balance).

2. **Removed `/tucznik zrezygnuj`** — it misled players into thinking they could withdraw at any time; it only worked before the roster was assigned. The `withdrawBirthday2026Registration` service stays (still covered by its database tests) in case it is needed by other flows.

## Tests executed

- `bun run typecheck` (`@hashira/bot` and all workspaces green)
- `bun x biome check --write` on changed files (clean)
- `bun test apps/bot/test/birthday2026/` — 50 pass, 0 fail (includes new `statsService.database.test.ts`: 2 pass)

## Screenshots

Admin-only ephemeral command; a sample of the generated `.txt` file:

```
Birthday 2026 - statystyki Paszy (9.08.2026, 14:00:00)

1) DRUŻYNY - łączna Pasza w drużynie
druzyna	waga_stala	koryto	pasza_lacznie	udzial_pct	karmiacy	czlonkowie
Team A	9000	3345	12345	80.0	5	2

2) ZAROBKI WG ZRODLA (na drużynę)
druzyna	czlonkowie	srednio_na_czlonka	tekst	glos	wydarzenia	granty_staffu	tekst_pct	glos_pct	wydarzenia_pct	granty_pct
Team A	2	100.0	90	40	20	50	45.0	20.0	10.0	25.0

3) CZŁONKOWIE - niewydana Pasza na osobę
user_id	druzyna	zarobiona	tekst	glos	wydarzenia	granty_staffu	przekazana	liczba_feedow	niewydana
111	Team A	200	90	40	20	50	160	3	40
```